### PR TITLE
Byebug.start_server should store the actual server port

### DIFF
--- a/lib/byebug/remote.rb
+++ b/lib/byebug/remote.rb
@@ -10,6 +10,9 @@ module Byebug
     # If in remote mode, wait for the remote connection
     attr_accessor :wait_connection
 
+    # The actual port that the server is started at
+    attr_accessor :actual_port
+
     #
     # Starts a remote byebug
     #
@@ -25,6 +28,7 @@ module Byebug
       proceed = ConditionVariable.new
 
       server = TCPServer.new(host, port)
+      self.actual_port = server.addr[1]
       @thread = DebugThread.new do
         while (session = server.accept)
           self.interface = RemoteInterface.new(session)


### PR DESCRIPTION
This change allows one to start the server on a randomly available port (by calling `Byebug.start_server("127.0.0.1", 0)`), and query that port number later. This functionality is necessary for Phusion Passenger, which starts multiple processes, each process which may listen on a different debugging port.
