### PR TITLE
should not use require_relative to load an extension library

### DIFF
--- a/lib/byebug.rb
+++ b/lib/byebug.rb
@@ -1,4 +1,4 @@
-require_relative 'byebug.so'
+require 'byebug.so'
 require_relative 'byebug/version'
 require_relative 'byebug/context'
 require_relative 'byebug/processor'


### PR DESCRIPTION
Extension libraries are placed in per-architecture directories, so `require_relative` is not good for them.
It caused a `LoadError` with recent RubyGems.
