### PR TITLE
Boolean values are allowed as settings values

### DIFF
--- a/lib/byebug/commands/set.rb
+++ b/lib/byebug/commands/set.rb
@@ -31,12 +31,12 @@ module Byebug
     def get_onoff(arg, default)
       return default if arg.nil?
       case arg
-      when '1', 'on'
+      when '1', 'on', 'true'
         return true
-      when '0', 'off'
+      when '0', 'off', 'false'
         return false
       else
-        print "Expecting 'on', 1, 'off', or 0. Got: #{arg}.\n"
+        print "Expecting 'on', 1, true, 'off', 0, false. Got: #{arg}.\n"
         raise RuntimeError
       end
     end

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -26,6 +26,12 @@ module SetTest
           Byebug::Setting[setting].must_equal true
         end
 
+        it "must set #{setting} to on using true" do
+          enter "set #{setting} true"
+          debug_proc(@example)
+          Byebug::Setting[setting].must_equal true
+        end
+
         it "must set #{setting} to on by default" do
           enter "set #{setting}"
           debug_proc(@example)
@@ -44,6 +50,12 @@ module SetTest
 
         it "must set #{setting} to on using 0" do
           enter "set #{setting} 0"
+          debug_proc(@example)
+          Byebug::Setting[setting].must_equal false
+        end
+
+        it "must set #{setting} to on using false" do
+          enter "set #{setting} false"
           debug_proc(@example)
           Byebug::Setting[setting].must_equal false
         end


### PR DESCRIPTION
Boolean values should be allowed as settings values. When I use 'save' command to save debugger state all settings are saved with boolean values as default. It caused problem when I try to revert the state of the debugger (source command).  
