### PR TITLE
BugFix: Make control-thread DebugerThead instead of normal Thread

### DIFF
--- a/lib/byebug/remote.rb
+++ b/lib/byebug/remote.rb
@@ -60,7 +60,7 @@ module Byebug
        return @actual_control_port if @control_thread
        server = TCPServer.new(host, ctrl_port)
        @actual_control_port = server.addr[1]
-       @control_thread = Thread.new do
+       @control_thread = DebugThread.new do
          while (session = server.accept)
            interface = RemoteInterface.new(session)
            ControlCommandProcessor.new(interface).process_commands


### PR DESCRIPTION
Usecase:
1. Start Debug process with Byebug.start_server
2. Connect to debug server with Byebug.start_client (port 8989)
3. Connect to control server with Byebug.start_client (port 8990)
4. Ensure debug server is active (not on 'continue')
5. Write any command on the control client (for example: b test.rb:5)

At that point the control client is not responsive due to 
thread halt (the halt is done automatically for each non debugger thread).

The fix convert the control thread to DebugThread (as it should be), and by that prevents
halting it by the debug mechanism.

For the record, this behavior is implemented correctly in Debugger gem.

Thanks,
Shuky
