### PR TITLE
Require Timeout to make test suite green on Ruby 2.0.0-p576

### DIFF
--- a/test/commands/eval_test.rb
+++ b/test/commands/eval_test.rb
@@ -29,6 +29,7 @@ module Byebug
     end
 
     def test_eval_properly_evaluates_an_expression_using_timeout
+      require 'timeout'
       enter 'eval Timeout::timeout(60) { 1 }'
       debug_proc(@example)
       check_output_includes '1'


### PR DESCRIPTION
Fixes #87 
