### PR TITLE
Add tests for LocalInterface, remote.rb

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,9 +10,13 @@ Rake::ExtensionTask.new('byebug', spec) do |ext|
   ext.lib_dir = 'lib/byebug'
 end
 
-desc 'Run the test suite'
+desc 'Run the test suite.  Run a single file with TEST=<file>'
 task :test do
-  files = Dir.glob('test/**/*_test.rb').join(' ')
+  if ENV['TEST']
+    files = ENV['TEST']
+  else
+    files = Dir.glob('test/**/*_test.rb').join(' ')
+  end
   system("ruby -w -Ilib test/test_helper.rb #{files}") || exit(false)
 end
 

--- a/lib/byebug/remote.rb
+++ b/lib/byebug/remote.rb
@@ -23,7 +23,7 @@ module Byebug
     # Starts a remote byebug
     #
     def start_server(host = nil, port = PORT)
-      return if @thread
+      return if defined?(@thread)
 
       handler.interface = nil
       start
@@ -48,7 +48,7 @@ module Byebug
     end
 
     def start_control(host = nil, ctrl_port = PORT + 1)
-      return @actual_control_port if @control_thread
+      return @actual_control_port if defined?(@control_thread)
       server = TCPServer.new(host, ctrl_port)
       @actual_control_port = server.addr[1]
       @control_thread = DebugThread.new do

--- a/lib/byebug/remote.rb
+++ b/lib/byebug/remote.rb
@@ -22,17 +22,18 @@ module Byebug
     #
     # Starts a remote byebug
     #
-    def start_server(host = nil, port = PORT)
+    def start_server(host = nil, port = PORT, mutex_factory: Mutex)
       return if defined?(@thread)
 
       handler.interface = nil
+
       start
 
       start_control(host, port == 0 ? 0 : port + 1)
 
       yield if block_given?
 
-      mutex = Mutex.new
+      mutex = mutex_factory.new
       proceed = ConditionVariable.new
 
       server = TCPServer.new(host, port)

--- a/test/interfaces/local_interface_test.rb
+++ b/test/interfaces/local_interface_test.rb
@@ -1,0 +1,31 @@
+require 'byebug/runner'
+require 'mocha/mini_test'
+
+module Byebug
+  class LocalInterfaceTest < Minitest::Test
+    def setup
+      @local_interface = LocalInterface.new
+    end
+
+    def test_readline_calls_out_to_std_lib_readline
+      Readline.expects(:readline).returns("bar")
+      result = @local_interface.readline ""
+
+      assert_equal("bar", result)
+    end
+
+    def test_readline_prints_escape_sequence_on_interrupt
+      Readline.stubs(:readline).raises(Interrupt, '').then.returns("")
+      @local_interface.expects(:puts).with('^C')
+
+      @local_interface.readline ""
+    end
+
+    def test_readline_retries_on_interrupt
+      Readline.expects(:readline).twice.raises(Interrupt, '').then.returns("")
+      @local_interface.stubs(:puts).with('^C')
+
+      @local_interface.readline ""
+    end
+  end
+end

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -12,11 +12,17 @@ module Byebug
         end
       end
 
-      def test_start_server_starts_only_one_thread
-        Mutex.expects(:new).once
+      class MutexTestWrapper
+        def self.new
+          Mutex.new
+        end
+      end
 
-        Byebug.start_server()
-        Byebug.start_server()
+      def test_start_server_starts_only_one_thread
+        MutexTestWrapper.expects(:new).once
+
+        Byebug.start_server(nil, 8989, mutex_factory: MutexTestWrapper)
+        Byebug.start_server(nil, 8989, mutex_factory: MutexTestWrapper)
       end
 
       def test_start_server_calls_a_block_passed_in

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -1,0 +1,32 @@
+require 'mocha/mini_test'
+
+module Byebug
+  module RemoteTest
+    class StartServerTest < TestCase
+      def teardown
+        # Byebug#start_server defines an instance variable on the Byebug
+        # metaclass during its first run.  This will pollute subsequent runs
+        # unless removed.
+        if Byebug.instance_variable_defined?(:@thread)
+          Byebug.remove_instance_variable(:@thread)
+        end
+      end
+
+      def test_start_server_starts_only_one_thread
+        Mutex.expects(:new).once
+
+        Byebug.start_server()
+        Byebug.start_server()
+      end
+
+      def test_start_server_calls_a_block_passed_in
+        Mutex.stubs(:new)
+        yielded = false
+        block = lambda { yielded = true }
+        Byebug.start_server(&block)
+
+        assert_equal(true, yielded)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Also changes an instance variable check to silence a warning when running the test suite with "ruby -w" (which is what `rake test` uses)