### PR TITLE
Fix setting breakpoints on module methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ sequentially.
 - Command history is now persisted before exiting byebug.
 - Setting breakpoint in a method would stop not only at the beginning of the
 method but also at the beginning of every block inside the method.
+- Setting breakpoints on module methods (#122).
 
 ### Removed
 - `autoreload` setting as it's not necessary anymore. Code should always be up

--- a/ext/byebug/breakpoint.c
+++ b/ext/byebug/breakpoint.c
@@ -417,7 +417,7 @@ check_breakpoint_by_method(VALUE rb_breakpoint, VALUE klass, ID mid, VALUE self)
     return 0;
 
   if (classname_cmp(breakpoint->source, klass)
-      || ((rb_type(self) == T_CLASS)
+      || ((rb_type(self) == T_CLASS || rb_type(self) == T_MODULE)
           && classname_cmp(breakpoint->source, self)))
     return 1;
 

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -91,6 +91,36 @@ module Byebug
     end
   end
 
+  class BreakAtModulesTestCase < TestCase
+    def program
+      strip_line_numbers <<-EOC
+          1:  module Byebug
+          2:    #
+          3:    # Toy module to test breakpoints
+          4:    #
+          5:    module #{example_module}
+          6:      def self.a
+          7:        1
+          8:      end
+          9:    end
+         10:
+         11:    byebug
+         12:
+         13:    #{example_module}.a
+         14:  end
+      EOC
+    end
+
+    def test_break_with_module_method_stops_at_correct_place
+      enter "break #{example_module}.a", 'cont'
+
+      debug_code(program) do
+        assert_equal 6, state.line
+        assert_equal example_path, state.file
+      end
+    end
+  end
+
   #
   # Tests breakpoint functionality.
   #

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -161,7 +161,7 @@ module Byebug
       end
     end
 
-    def test_breaking_w_byebug_keywork_stops_at_the_next_line
+    def test_breaking_w_byebug_keyword_stops_at_the_next_line
       debug_code(program) { assert_equal 15, state.line }
     end
 

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -74,5 +74,11 @@ module Byebug
     def example_class
       camelize(File.basename(example_path, '.rb'))
     end
+    #
+    # Name of the temporary test module.
+    #
+    def example_module
+      camelize(File.basename(example_path, '.rb'))
+    end
   end
 end


### PR DESCRIPTION
[It](https://github.com/deivid-rodriguez/byebug/issues/122) took less than I expected. If I haven't introduced any new issues with this commit, that is. And running `CCop` failed, not sure what this means:

```
Running CCop...
Inspecting 5 files
rake aborted!
Errno::ENOENT: No such file or directory @ rb_file_s_size - ext/byebug/byebug.c_corrected
/home/yuri/_/byebug/tasks/ccop.rb:28:in `block (2 levels) in <top (required)>'
/home/yuri/_/byebug/tasks/ccop.rb:23:in `each'
/home/yuri/_/byebug/tasks/ccop.rb:23:in `block in <top (required)>'
Tasks: TOP => default => ccop
(See full trace by running task with --trace)
```

By the way, you can contribute to [this question](http://stackoverflow.com/questions/28608097/how-do-i-debug-ruby-c-extensions) if you've got anything to add.