### PR TITLE
Pass file/line to 'break.created' print

### DIFF
--- a/lib/byebug/commands/break.rb
+++ b/lib/byebug/commands/break.rb
@@ -14,7 +14,11 @@ module Byebug
       return puts(self.class.help) if self.class.names.include?(@match[0])
 
       brkpt = line_breakpoint(@match[1]) || method_breakpoint(@match[1])
-      return puts(pr('break.created', id: brkpt.id)) if syntax_valid?(@match[2])
+      if syntax_valid?(@match[2])
+        return puts(
+          pr('break.created', id: brkpt.id, file: brkpt.source, line: brkpt.pos)
+        )
+      end
 
       errmsg(pr('break.errors.expression', expr: @match[2]))
       brkpt.enabled = false


### PR DESCRIPTION
Necessary for debugger-xml, since it has to pass that information to IDE