### PR TITLE
thread list command fixed to work with debugger-xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ Gemfile.lock
 lib/byebug/byebug.so
 lib/byebug/byebug.bundle
 .ruby-version
+.ruby-gemset
+.idea

--- a/lib/byebug/commands/thread.rb
+++ b/lib/byebug/commands/thread.rb
@@ -114,7 +114,10 @@ module Byebug
         debug_flag: debug_flag,
         id: context.thnum,
         thread: context.thread.inspect,
-        file_line: file_line || ''
+        file_line: file_line || '',
+        pid: Process.pid,
+        status: context.thread.status,
+        current: (context.thread == Thread.current)
       }
     end
 

--- a/lib/byebug/commands/thread.rb
+++ b/lib/byebug/commands/thread.rb
@@ -52,7 +52,7 @@ module Byebug
         thread_arguments(context)
       end
 
-      print(thread_list)
+      puts(thread_list)
     end
 
     def thread_current(thnum)

--- a/lib/byebug/commands/var.rb
+++ b/lib/byebug/commands/var.rb
@@ -18,7 +18,7 @@ module Byebug
         end
         [v, s]
       end
-      puts prv(vars)
+      puts prv(vars, 'instance')
     end
 
     def var_global(_str = nil)
@@ -41,13 +41,13 @@ module Byebug
       return errmsg(pr('variable.errors.not_module', object: str)) unless is_mod
 
       constants = bb_eval("#{str}.constants")
-      puts prv(constants.sort.map { |c| [c, obj.const_get(c)] })
+      puts prv(constants.sort.map { |c| [c, obj.const_get(c)] }, 'constant')
     end
 
     def var_local(_str = nil)
       _self = @state.context.frame_self(@state.frame)
       locals = @state.context.frame_locals
-      puts prv(locals.keys.sort.map { |k| [k, locals[k]] })
+      puts prv(locals.keys.sort.map { |k| [k, locals[k]] }, 'instance')
     end
 
     def var_all(_str = nil)

--- a/lib/byebug/commands/var.rb
+++ b/lib/byebug/commands/var.rb
@@ -45,8 +45,9 @@ module Byebug
     end
 
     def var_local(_str = nil)
-      _self = @state.context.frame_self(@state.frame)
+      cur_self = @state.context.frame_self(@state.frame)
       locals = @state.context.frame_locals
+      locals[:self] = cur_self unless cur_self.to_s == 'main'
       puts prv(locals.keys.sort.map { |k| [k, locals[k]] }, 'instance')
     end
 

--- a/lib/byebug/printers/plain.rb
+++ b/lib/byebug/printers/plain.rb
@@ -24,7 +24,7 @@ module Byebug
         end
       end
 
-      def print_variables(variables)
+      def print_variables(variables, *_)
         print_collection('variable.variable', variables) do |(key, value), _|
           value = value.nil? ? 'nil' : value.to_s
           if "#{key} = #{value}".size > Setting[:width]

--- a/test/commands/stepping_test.rb
+++ b/test/commands/stepping_test.rb
@@ -27,12 +27,18 @@ module Byebug
 
     def test_next_goes_to_the_next_line
       enter 'next'
-      debug_code(program) { assert_equal 16, state.line }
+      debug_code(program) do
+        assert_equal 16, state.line,
+                     "Unexpected position: #{state.file}:#{state.line}"
+      end
     end
 
     def test_n_goes_to_the_next_line
       enter 'n'
-      debug_code(program) { assert_equal 16, state.line }
+      debug_code(program) do
+        assert_equal 16, state.line,
+                     "Unexpected position: #{state.file}:#{state.line}"
+      end
     end
 
     def test_step_goes_to_the_next_statement


### PR DESCRIPTION
the debugger-xml+byebug+RubyMine integration is not complete, but this is the first problem I've found and (I hope) fixed.
For some reasons I was unable to run indent command on Mac
IMHO it would be nice to known what exact version of the utility we are supposed to use.