### PR TITLE
No more monkey patching

### DIFF
--- a/lib/byebug/commands/eval.rb
+++ b/lib/byebug/commands/eval.rb
@@ -54,8 +54,6 @@ module Byebug
   class EvalCommand < Command
     include EvalFunctions
 
-    self.allow_in_control = true
-
     def match(input)
       @input = input
       super

--- a/lib/byebug/commands/frame.rb
+++ b/lib/byebug/commands/frame.rb
@@ -54,12 +54,14 @@ module Byebug
 
     def get_pr_arguments(frame_no)
       file = @state.frame_file(frame_no)
+      full_path = File.expand_path(file)
       line = @state.frame_line(frame_no)
       call = @state.frame_call(frame_no)
       mark = @state.frame_mark(frame_no)
       pos = @state.frame_pos(frame_no)
 
-      { mark: mark, pos: pos, call: call, file: file, line: line }
+      { mark: mark, pos: pos, call: call, file: file,
+        line: line, full_path: full_path }
     end
   end
 


### PR DESCRIPTION
I've added some information debugger-xml needs from byebug to remove monkey-patching from debugger-xml.
I've made a small change in var.rb which will not allow us to remove monkey-patching completely because we do provide additional sub-commands and replace couple methods (see https://github.com/astashov/debugger-xml/blob/master/lib/byebug/commands/variables.rb)  Any ideas how to improve that is welcome.

Also debugger-xml monkey-patches several commands to make them "unsupported" (e.g. https://github.com/astashov/debugger-xml/blob/master/lib/byebug/commands/help.rb)
Again any ideas how to fix this w/o monkey-patching are welcome ;)