### PR TITLE
make frame cmd work with negative arg

### DIFF
--- a/lib/byebug/helpers/parse.rb
+++ b/lib/byebug/helpers/parse.rb
@@ -10,7 +10,7 @@ module Byebug
       # If either +min+ or +max+ is nil, that value has no bound.
       #
       def get_int(str, cmd, min = nil, max = nil)
-        if str !~ /\A[0-9]+\z/
+        if str !~ /\A-?[0-9]+\z/
           err = pr('parse.errors.int.not_number', cmd: cmd, str: str)
           return nil, errmsg(err)
         end


### PR DESCRIPTION
 for frame cmd to work correctly, 
adjust_frame() at line 29 (in  [byebug/commands/frame.rb ](https://github.com/deivid-rodriguez/byebug/blob/master/lib/byebug/commands/frame.rb)) should be invoked, 
but, it doesn't, because pos is assined to nil  and execute() returns at line 27.
```
20    def execute()
~
26       pos, err = get_int(@match[1], 'Frame')
27             return errmsg(err) unless pos
28
29             adjust_frame(pos, true)
```


The nil comes from the statement at line 15 (in [byebug/helpers/parse.rb](https://github.com/deivid-rodriguez/byebug/blob/master/lib/byebug/helpers/parse.rb)),
due to the regular expression at line 13, which is evaluated as false, given str negative number.
```
12    def get_int(str, cmd, min = nil, max = nil)
13      if str !~ /\A[0-9]+\z/
14        err = pr('parse.errors.int.not_number', cmd: cmd, str: str)
15        return nil, errmsg(err)
16      end
~
```


So that it matches negative number, modifing as following:
```
13      if str !~ /\A-?[0-9]+\z/
```



