### PR TITLE
Disable tracepoints after continue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ### Fixed
 * [#177](https://github.com/deivid-rodriguez/byebug/issues/177). Some issues
 with formatting results of evaluations.
+* [#144](https://github.com/deivid-rodriguez/byebug/issues/144). Ruby process
+after using byebug does no longer get slow.
 * [#121](https://github.com/deivid-rodriguez/byebug/issues/121). `byebug`
 commands inside code evaluated from debugger's prompt are now properly working.
 * Another evaluation bug in autocommands.

--- a/lib/byebug/commands/continue.rb
+++ b/lib/byebug/commands/continue.rb
@@ -41,6 +41,8 @@ module Byebug
       end
 
       processor.proceed!
+
+      Byebug.stop if Byebug.stoppable?
     end
   end
 end

--- a/lib/byebug/interfaces/local_interface.rb
+++ b/lib/byebug/interfaces/local_interface.rb
@@ -3,6 +3,8 @@ module Byebug
   # Interface class for standard byebug use.
   #
   class LocalInterface < Interface
+    EOF_ALIAS = 'continue'
+
     def initialize
       super()
       @input = STDIN
@@ -13,12 +15,12 @@ module Byebug
     #
     # Reads a single line of input using Readline. If Ctrl-C is pressed in the
     # middle of input, the line is reset to only the prompt and we ask for input
-    # again.
+    # again. If Ctrl-D is pressed, it returns "continue".
     #
     # @param prompt Prompt to be displayed.
     #
     def readline(prompt)
-      Readline.readline(prompt, false)
+      Readline.readline(prompt, false) || EOF_ALIAS
     rescue Interrupt
       puts('^C')
       retry

--- a/test/commands/continue_test.rb
+++ b/test/commands/continue_test.rb
@@ -32,6 +32,12 @@ module Byebug
       debug_code(program) { assert_program_finished }
     end
 
+    def test_stops_byebug_after_continue
+      enter 'continue'
+
+      debug_code(program) { assert_equal false, Byebug.started? }
+    end
+
     def test_continues_up_to_breakpoint_if_no_line_specified
       enter 'break 14', 'continue'
 

--- a/test/interfaces/local_interface_test.rb
+++ b/test/interfaces/local_interface_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+require 'minitest/mock'
+
+module Byebug
+  #
+  # Tests the local interface
+  #
+  class LocalInterfaceTest < TestCase
+    def test_continues_by_control_d
+      # `Readline.readline` returns nil for Control-D
+      Readline.stub(:readline, nil) do
+        interface = LocalInterface.new
+        assert_equal 'continue', interface.readline('(byebug)')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/deivid-rodriguez/byebug/issues/144.

I couldn't find out how to avoid SEGV in tests and what a correct fix would be. I'm just sharing my idea.
`Byebug.start` enables tracepoints and they are left enabled after `continue`. If tracepoints are enabled, it gets slow. In fact, this branch does not change things slow after `continue`. I want to disable them while I'm not debugging.

I think we can disable tracepoints after `continue` or ^D and enable them again when `byebug` or `debugger` is called. Is there any reason to keep tracepoints enabled all the time?