### PR TITLE
Remove `exit` command from the README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ are debugging rails, start the server and once the execution gets to your
     `next`      |              |
     `pry`       |              |
     `ps`        |              |
-    `quit`      | `exit`       |
+    `quit`      |              |
     `restart`   |              |
     `save`      |              |
     `set`       |              | `autoirb` `autolist` `autosave` `basename` `callstyle` `fullpath` `histfile` `histsize` `linetrace` `listsize` `post_mortem` `savefile` `stack_on_error` `width`


### PR DESCRIPTION
As per commit 76702a2:

https://github.com/deivid-rodriguez/byebug/commit/76702a255b9edf754cdd51
c238b76af132b784ec

Thanks for the great gem!