### PR TITLE
Don't load entire library up front

### DIFF
--- a/lib/byebug.rb
+++ b/lib/byebug.rb
@@ -1,2 +1,1 @@
-require 'byebug/core'
 require 'byebug/attacher'

--- a/lib/byebug/attacher.rb
+++ b/lib/byebug/attacher.rb
@@ -7,6 +7,8 @@ module Byebug
   # events occur. Before entering byebug the init script is read.
   #
   def self.attach
+    require 'byebug/core'
+
     unless started?
       self.mode = :attached
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require 'support/coverage'
 require 'minitest'
 require 'byebug'
+require 'byebug/core'
 require 'byebug/interfaces/test_interface'
 require 'support/utils'
 


### PR DESCRIPTION
When running tests, it is nice to both have the `byebug` command available, and to have the tests start up really fast.

Fixes #166.