### PR TITLE
Listing if there's no source file

### DIFF
--- a/lib/byebug/commands/list.rb
+++ b/lib/byebug/commands/list.rb
@@ -35,8 +35,14 @@ module Byebug
     end
 
     def execute
-      msg = "No sourcefile available for #{frame.file}"
-      fail(msg) unless File.exist?(frame.file)
+      if !File.exist?(frame.file)
+        context.step_into 1
+        processor.proceed!
+        return
+      end
+
+      # msg = "No sourcefile available for #{frame.file}"
+      # fail(msg) unless File.exist?(frame.file)
 
       max_lines = n_lines(frame.file)
       b, e = range(@match[2], max_lines)


### PR DESCRIPTION
A common scenario of missing source files is debugging through dynamically generated code. In this case (and probably in any other case where source file is not to be found), it may be better to step through the source-less code and to resume debugging at the next available source line.
Anyway, just failing on missing source file crashes byebug on dynamically generated code.