### PR TITLE
option `-s` broken

### DIFF
--- a/lib/byebug/runner.rb
+++ b/lib/byebug/runner.rb
@@ -36,7 +36,7 @@ module Byebug
     #
     # Signals that we should exit after the debugged program is finished.
     #
-    attr_accessor :quit
+    attr_accessor :quit, :stop
 
     #
     # @param stop [Boolean] Whether the runner should stop right before


### PR DESCRIPTION
lib/byebug/option_setter.rb:59:in `block in stop': undefined method `stop=' for #<Byebug::Runner:0x0000011102abe0 @stop=true, @quit=true> (NoMethodError)