### PR TITLE
change variable name bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ commands inside code evaluated from debugger's prompt are now properly working.
 * `finish 0` command would sometimes fail to stop right before exiting the
 current frame.
 * Runner's `--[no-]stop` option now works (thanks @windwiny).
+* Change variable name `bool`, avoid conflict clang's predefined macro
 
 ### Removed
 * `ps` command.

--- a/ext/byebug/breakpoint.c
+++ b/ext/byebug/breakpoint.c
@@ -38,17 +38,17 @@ brkpt_enabled(VALUE self)
 
 /*
  *  call-seq:
- *    breakpoint.enabled = bool
+ *    breakpoint.enabled = true | false
  *
  *  Enables or disables breakpoint.
  */
 static VALUE
-brkpt_set_enabled(VALUE self, VALUE bool)
+brkpt_set_enabled(VALUE self, VALUE enabled)
 {
   breakpoint_t *breakpoint;
 
   Data_Get_Struct(self, breakpoint_t, breakpoint);
-  return breakpoint->enabled = bool;
+  return breakpoint->enabled = enabled;
 }
 
 /*


### PR DESCRIPTION
because xcode clang define bool macro

    Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/7.0.0/include/stdbool.h:31:14: note:
          expanded from macro 'bool'
    #define bool _Bool