### PR TITLE
Return true as boolean if byebug is already started

### DIFF
--- a/ext/byebug/byebug.c
+++ b/ext/byebug/byebug.c
@@ -630,7 +630,7 @@ Started(VALUE self)
 {
   UNUSED(self);
 
-  return IS_STARTED;
+  return IS_STARTED ? Qtrue : Qfalse;
 }
 
 /*


### PR DESCRIPTION
This is very minor issue.

`Byebug.started?` return `false` when breakpoints hasn't been set.
`Byebug.started?` return `0` when some breakpoints has been set.
