### PR TITLE
Guide.md: update remote debugging instructions

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1354,7 +1354,7 @@ program that you want to debug (In Rails, the
 `config/environments/development.rb` could be a good candidate).
 
 ```ruby
-  require 'byebug'
+  require 'byebug/core'
   Byebug.wait_connection = true
   Byebug.start_server('localhost', <port>)
 ```


### PR DESCRIPTION
Change "require 'byebug'" to require "'byebug/core'."
Issue: https://github.com/deivid-rodriguez/byebug/issues/195