### PR TITLE
Better file path acceptance for b[reak]

### DIFF
--- a/lib/byebug/commands/break.rb
+++ b/lib/byebug/commands/break.rb
@@ -15,7 +15,7 @@ module Byebug
     self.allow_in_control = true
 
     def self.regexp
-      /^\s* b(?:reak)? (?:\s+ (.+))? (?:\s+ if \s+(.+))? \s*$/x
+      /^\s* b(?:reak)? (?:\s+ (.+?))? (?:\s+ if \s+(.+))? \s*$/x
     end
 
     def self.description

--- a/lib/byebug/commands/break.rb
+++ b/lib/byebug/commands/break.rb
@@ -15,7 +15,7 @@ module Byebug
     self.allow_in_control = true
 
     def self.regexp
-      /^\s* b(?:reak)? (?:\s+ (\S+))? (?:\s+ if \s+(.+))? \s*$/x
+      /^\s* b(?:reak)? (?:\s+ (.+))? (?:\s+ if \s+(.+))? \s*$/x
     end
 
     def self.description
@@ -52,7 +52,7 @@ module Byebug
 
     def line_breakpoint(location)
       line_match = location.match(/^(\d+)$/)
-      file_line_match = location.match(/^([^:]+):(\d+)$/)
+      file_line_match = location.match(/^(.+):(\d+)$/)
       return unless line_match || file_line_match
 
       file = line_match ? frame.file : file_line_match[1]
@@ -62,7 +62,7 @@ module Byebug
     end
 
     def method_breakpoint(location)
-      location.match(/([^.#]+)[.#](.+)/) do |match|
+      location.match(/^([^.#]+)[.#](.+)/) do |match|
         klass = target_object(match[1])
         method = match[2].intern
 

--- a/lib/byebug/commands/info/file.rb
+++ b/lib/byebug/commands/info/file.rb
@@ -14,7 +14,7 @@ module Byebug
       self.allow_in_post_mortem = true
 
       def self.regexp
-        /^\s* f(?:ile)? (?:\s+ (\S+))? \s*$/x
+        /^\s* f(?:ile)? (?:\s+ (.+))? \s*$/x
       end
 
       def self.description

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -385,17 +385,17 @@ module Byebug
     end
 
     def example_class
-      "TestFolder"
+      'TestFolder'
     end
 
     def example_module
-      "TestFolder"
+      'TestFolder'
     end
 
     #
     # Temporary file where code for each test is saved
     # Overloaded for space in name
-    # 
+    #
     def example_file
       @example_file ||= Tempfile.new(['byebug space test', '.rb'])
 
@@ -413,18 +413,18 @@ module Byebug
       enter 'break ../relative/path space.rb:8'
       debug_code(program)
 
-      check_error_includes "No file named ../relative/path space.rb"
+      check_error_includes 'No file named ../relative/path space.rb'
     end
 
     def test_setting_breakpoint_with_relative_path
-      enter "break ./test/commands/break_test.rb:8"
+      enter 'break ./test/commands/break_test.rb:8'
       debug_code(program)
 
       check_output_includes(/Successfully created breakpoint with id/)
     end
 
     def test_setting_conditional_breakpoint_with_relative_path
-      enter "break ./test/commands/break_test.rb:8 if y == 1"
+      enter 'break ./test/commands/break_test.rb:8 if y == 1'
       debug_code(program)
 
       check_output_includes(/Successfully created breakpoint with id/)

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -134,7 +134,7 @@ module Byebug
     end
 
     def test_setting_breakpoint_sets_correct_fields
-      enter 'break 7'
+      enter "break #{example_path}:7"
 
       debug_code(program) do
         b = Breakpoint.first
@@ -356,6 +356,78 @@ module Byebug
       debug_code(program)
 
       check_output_doesnt_include 'Return value is: nil'
+    end
+  end
+
+  #
+  # Tests breakpoints with path containing space and relative path
+  #
+  class BreakAtLinesFileNameTest < TestCase
+    def program
+      strip_line_numbers <<-EOC
+         1:  module Byebug
+         2:    #
+         3:    # Toy class to test breakpoints
+         4:    #
+         5:    class TestFolder
+         6:      def self.a
+         7:        y = 1
+         8:        z = 2
+         9:        y + z
+        10:      end
+        11:    end
+        12:
+        13:    byebug
+        14:
+        15:    TestFolder.a
+        16:  end
+      EOC
+    end
+
+    def example_class
+      "TestFolder"
+    end
+
+    def example_module
+      "TestFolder"
+    end
+
+    #
+    # Temporary file where code for each test is saved
+    # Overloaded for space in name
+    # 
+    def example_file
+      @example_file ||= Tempfile.new(['byebug space test', '.rb'])
+
+      @example_file.open if @example_file.closed?
+
+      @example_file
+    end
+
+    def test_setting_breakpoint_with_full_path_adds_the_breakpoint
+      enter "break #{example_path}:7"
+      debug_code(program) { assert_equal 1, Byebug.breakpoints.size }
+    end
+
+    def test_setting_breakpoint_with_bad_relative_path_doesnt_crash
+      enter 'break ../relative/path space.rb:8'
+      debug_code(program)
+
+      check_error_includes "No file named ../relative/path space.rb"
+    end
+
+    def test_setting_breakpoint_with_relative_path
+      enter "break ./test/commands/break_test.rb:8"
+      debug_code(program)
+
+      check_output_includes(/Successfully created breakpoint with id/)
+    end
+
+    def test_setting_conditional_breakpoint_with_relative_path
+      enter "break ./test/commands/break_test.rb:8 if y == 1"
+      debug_code(program)
+
+      check_output_includes(/Successfully created breakpoint with id/)
     end
   end
 end

--- a/test/commands/info_test.rb
+++ b/test/commands/info_test.rb
@@ -267,7 +267,7 @@ module Byebug
     def test_info_file_reads_relative_path
       enter 'info file ./test/commands/info_test.rb'
       debug_code(program)
-      check_output_includes(%r{/test/commands/info_test.rb (\d* lines)})
+      check_output_includes(%r{File .*/test/commands/info_test.rb })
     end
   end
 end

--- a/test/commands/info_test.rb
+++ b/test/commands/info_test.rb
@@ -100,6 +100,13 @@ module Byebug
       check_output_includes "File #{example_path} (27 lines)"
     end
 
+    def test_info_file_reads_relative_path
+      enter 'info file ./test/commands/info_test.rb'
+      debug_code(program)
+
+      check_output_includes(/File .*\/test\/commands\/info_test.rb \(\d* lines\)/)
+    end
+
     def test_info_file_with_a_file_name_shows_basic_info_about_a_specific_file
       with_new_tempfile('sleep 0') do |script_name|
         enter "info file #{script_name}"

--- a/test/commands/info_test.rb
+++ b/test/commands/info_test.rb
@@ -100,13 +100,6 @@ module Byebug
       check_output_includes "File #{example_path} (27 lines)"
     end
 
-    def test_info_file_reads_relative_path
-      enter 'info file ./test/commands/info_test.rb'
-      debug_code(program)
-
-      check_output_includes(/File .*\/test\/commands\/info_test.rb \(\d* lines\)/)
-    end
-
     def test_info_file_with_a_file_name_shows_basic_info_about_a_specific_file
       with_new_tempfile('sleep 0') do |script_name|
         enter "info file #{script_name}"
@@ -232,6 +225,49 @@ module Byebug
 
       assert_raises(RuntimeError) { debug_code(program_raising) }
       check_output_includes 'Program stopped.', 'It stopped at a catchpoint.'
+    end
+  end
+
+  #
+  # Tests info on relative file path
+  #
+  class InfoFileRelativeTest < TestCase
+    def program
+      strip_line_numbers <<-EOC
+         1:  module Byebug
+         2:    #
+         3:    # Toy class to test information about files.
+         4:    #
+         5:    class #{example_class}
+         6:      def initialize
+         7:        @foo = 'bar'
+         8:        @bla = 'blabla'
+         9:      end
+        10:
+        11:      def a(y, z)
+        12:        w = '1' * 45
+        13:        x = 2
+        14:        w + x.to_s + y + z + @foo
+        15:      end
+        16:
+        17:      def b
+        18:        a('a', 'b')
+        19:        e = '%.2f'
+        20:        e
+        21:      end
+        22:    end
+        23:
+        24:    byebug
+        25:    i = #{example_class}.new
+        26:    i.b
+        27:  end
+      EOC
+    end
+
+    def test_info_file_reads_relative_path
+      enter 'info file ./test/commands/info_test.rb'
+      debug_code(program)
+      check_output_includes(%r{/test/commands/info_test.rb (\d* lines)})
     end
   end
 end


### PR DESCRIPTION
Enables adding break points with files names such as:
```
../Test/Relative/path.rb
/Test Space/path.rb
c:/Test_Windows/path.rb
```

Also eliminates crash when forgetting to type the line number (oops :wink:) with a relative path. Currently: `break ../file.rb` will crash as it attempts to resolve that line as a `class.method` of `/file.rb`.

