### PR TITLE
Use IO.console for readline over STD{IN,OUT,ERR}.

### DIFF
--- a/lib/byebug/interfaces/local_interface.rb
+++ b/lib/byebug/interfaces/local_interface.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'io/console'
+
 module Byebug
   #
   # Interface class for standard byebug use.
@@ -8,9 +10,9 @@ module Byebug
 
     def initialize
       super()
-      @input = STDIN
-      @output = STDOUT
-      @error = STDERR
+      @input = @output = @error = IO.console
+      Readline.input = @input
+      Readline.output = @output
     end
 
     #


### PR DESCRIPTION
I've been testing this for a few weeks to debug programs that read from stdin and write to stdout. This is the way I'm accustomed to other debuggers working out of the box.