### PR TITLE
Support space in filename for break and info file

### DIFF
--- a/lib/byebug/commands/break.rb
+++ b/lib/byebug/commands/break.rb
@@ -15,7 +15,7 @@ module Byebug
     self.allow_in_control = true
 
     def self.regexp
-      /^\s* b(?:reak)? (?:\s+ (\S+))? (?:\s+ if \s+(.+))? \s*$/x
+      /^\s* b(?:reak)? (?:\s+ (.+?))? (?:\s+ if \s+(.+))? \s*$/x
     end
 
     def self.description
@@ -52,7 +52,7 @@ module Byebug
 
     def line_breakpoint(location)
       line_match = location.match(/^(\d+)$/)
-      file_line_match = location.match(/^([^:]+):(\d+)$/)
+      file_line_match = location.match(/^(.+):(\d+)$/)
       return unless line_match || file_line_match
 
       file = line_match ? frame.file : file_line_match[1]

--- a/lib/byebug/commands/info/file.rb
+++ b/lib/byebug/commands/info/file.rb
@@ -14,7 +14,7 @@ module Byebug
       self.allow_in_post_mortem = true
 
       def self.regexp
-        /^\s* f(?:ile)? (?:\s+ (\S+))? \s*$/x
+        /^\s* f(?:ile)? (?:\s+ (.+))? \s*$/x
       end
 
       def self.description

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -109,6 +109,74 @@ module Byebug
   end
 
   #
+  # Tests adding breakpoints to file with space in filename
+  #
+  class BreakWithSpaceInFilenameTest < TestCase
+    def program
+      strip_line_numbers <<-EOC
+         1:  module Byebug
+         2:    #
+         3:    # Toy class to test breakpoints
+         4:    #
+         5:    class TestClass
+         6:      def self.a
+         7:        y = 1
+         8:        z = 2
+         9:        y + z
+        10:      end
+        11:    end
+        12:
+        13:    byebug
+        14:
+        15:    TestClass.a
+        16:  end
+      EOC
+    end
+
+    #
+    # Fully namespaced example class
+    #
+    def example_full_class
+      'Byebug::TestClass'
+    end
+
+    #
+    # Name of the temporary test class.
+    #
+    def example_class
+      'TestClass'
+    end
+
+    #
+    # Name of the temporary test module.
+    #
+    def example_module
+      'TestModule'
+    end
+
+    def example_file
+      @example_file ||= Tempfile.new(['byebug space test', '.rb'])
+
+      @example_file.open if @example_file.closed?
+
+      @example_file
+    end
+
+    def test_setting_breakpoint_with_space_in_path_adds_the_breakpoint
+      enter "break #{example_path}:8"
+      debug_code(program)
+
+      check_output_includes(/Successfully created breakpoint with id/)
+    end
+
+    def test_setting_breakpoint_to_nonexistent_file_with_space_shows_an_error
+      enter 'break /this path/isnt there/abc xyz:8'
+      debug_code(program)
+
+      check_error_includes 'No file named /this path/isnt there/abc xyz'
+    end
+  end
+  #
   # Tests adding breakpoints to lines
   #
   class BreakAtLinesTest < TestCase

--- a/test/commands/info_test.rb
+++ b/test/commands/info_test.rb
@@ -209,6 +209,50 @@ module Byebug
   end
 
   #
+  # Test info command with space in filename.
+  #
+  class InfoFileWithSpaceTest < TestCase
+    def program
+      strip_line_numbers <<-EOC
+         1:  module Byebug
+         2:    #
+         3:    # Toy class to test information about files.
+         4:    #
+         5:    class #{example_class}
+         6:      def initialize
+         7:        @foo = 'bar'
+         8:        @bla = 'blabla'
+         9:      end
+        10:
+        11:      def a(y, z)
+        12:        w = '1' * 45
+        13:        x = 2
+        14:        w + x.to_s + y + z + @foo
+        15:      end
+        16:
+        17:      def b
+        18:        a('a', 'b')
+        19:        e = '%.2f'
+        20:        e
+        21:      end
+        22:    end
+        23:
+        24:    byebug
+        25:    i = #{example_class}.new
+        26:    i.b
+        27:  end
+      EOC
+    end
+
+    def test_info_file_with_a_file_name_with_space_doesnt_fail
+      enter 'info file /file name/with space/file'
+      debug_code(program)
+
+      check_error_includes ' is not a valid source file'
+    end
+  end
+
+  #
   # Tests info command on crashed programs
   #
   class InfoCrashedTest < TestCase

--- a/test/commands/info_test.rb
+++ b/test/commands/info_test.rb
@@ -245,10 +245,11 @@ module Byebug
     end
 
     def test_info_file_with_a_file_name_with_space_doesnt_fail
-      enter 'info file /file name/with space/file'
+      name_with_spaces = '/file name/with space/file'
+      enter "info file #{name_with_spaces}"
       debug_code(program)
 
-      check_error_includes ' is not a valid source file'
+      check_error_includes "#{name_with_spaces} is not a valid source file"
     end
   end
 


### PR DESCRIPTION
I did something wrong that ruined my last fork so I started again. As discussed on [the last request](https://github.com/deivid-rodriguez/byebug/pull/210), this mods the `break` and `info file` commands to allow spaces in filenames. Tests added.