### PR TITLE
Fix windows build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem 'rake', '~> 11.1'
 
-gem 'rake-compiler', '0.9.6'
+gem 'rake-compiler', '0.9.5'
 gem 'rubocop', '0.38.0'
 gem 'mocha', '~> 1.1'
 gem 'minitest', '~> 5.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       websocket (~> 1.0)
     rainbow (2.1.0)
     rake (11.1.1)
-    rake-compiler (0.9.6)
+    rake-compiler (0.9.5)
       rake
     rubocop (0.38.0)
       parser (>= 2.3.0.6, < 3.0)
@@ -111,7 +111,7 @@ DEPENDENCIES
   overcommit (= 0.32.0)
   pry!
   rake (~> 11.1)
-  rake-compiler (= 0.9.6)
+  rake-compiler (= 0.9.5)
   rubocop (= 0.38.0)
   simplecov (= 0.11.2)
   travis (~> 1.8)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,6 @@
 
 version: "{build}"
 
-branches:
-  only:
-    - master
-
 install:
   - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%


### PR DESCRIPTION
Using `rake-compiler` 0.9.6 breaks Windows build.