### PR TITLE
Log .byebugrc errors to the console

### DIFF
--- a/lib/byebug/interfaces/script_interface.rb
+++ b/lib/byebug/interfaces/script_interface.rb
@@ -1,3 +1,5 @@
+require 'io/console'
+
 module Byebug
   #
   # Interface class for command execution from script files.
@@ -6,8 +8,9 @@ module Byebug
     def initialize(file, verbose = false)
       super()
       @input = File.open(file)
-      @output = verbose ? STDOUT : StringIO.new
-      @error = verbose ? STDERR : StringIO.new
+      @verbose = verbose
+      @error = IO.console
+      @output = verbose ? @error : File.open(File::NULL, File::WRONLY)
     end
 
     def read_command(prompt)
@@ -16,11 +19,12 @@ module Byebug
 
     def close
       input.close
+      @output.close
     end
 
     def readline(*)
       while (result = input.gets)
-        output.puts "+ #{result}"
+        output.puts "+ #{result}" if @verbose
         next if result =~ /^\s*#/
         return result.chomp
       end

--- a/tasks/dev_utils.rb
+++ b/tasks/dev_utils.rb
@@ -43,7 +43,7 @@ class LoopRunner
 end
 
 #
-# @example Tun tests 8 times for each supported Ruby
+# @example Run tests 8 times for each supported Ruby
 #
 #   $ rake loop_tests
 #

--- a/test/interfaces/script_interface_test.rb
+++ b/test/interfaces/script_interface_test.rb
@@ -10,18 +10,18 @@ module Byebug
         interface = ScriptInterface.new(path)
 
         assert_instance_of File, interface.input
-        assert_instance_of StringIO, interface.output
-        assert_instance_of StringIO, interface.error
+        assert_instance_of File, interface.output
+        assert_instance_of File, interface.error
       end
     end
 
-    def test_initialize_verbose_writes_to_stdout_and_stderr
+    def test_initialize_verbose_writes_to_terminal
       with_new_tempfile('show') do |path|
         interface = ScriptInterface.new(path, true)
 
         assert_instance_of File, interface.input
-        assert_equal STDOUT, interface.output
-        assert_equal STDERR, interface.error
+        assert interface.output.tty?
+        assert interface.error.tty?
       end
     end
 


### PR DESCRIPTION
I notice there used to be a verbose option, which I think could be used to echo ``.byebugrc`` commands as they are executed. For now the verbose option of ``ScriptInterface`` doesn't seem to be connected to anything.