### PR TITLE
Remove not defined function from byebug.h

### DIFF
--- a/ext/byebug/byebug.h
+++ b/ext/byebug/byebug.h
@@ -121,9 +121,6 @@ extern VALUE context_backtrace_set(const rb_debug_inspector_t * inspector,
 
 /* functions from breakpoint.c */
 extern void Init_breakpoint(VALUE mByebug);
-extern VALUE catchpoint_hit_count(VALUE catchpoints, VALUE exception,
-                                  VALUE * exception_name);
-
 extern VALUE find_breakpoint_by_pos(VALUE breakpoints, VALUE source, VALUE pos,
                                     VALUE bind);
 


### PR DESCRIPTION
`catchpoint_hit_count` is deleted by
a3eb12c58cd1f1bc3f63e26c0af71a8dc46641df