### PR TITLE
Use global instead of constant stdin, stdout and stderr

### DIFF
--- a/lib/byebug/interfaces/local_interface.rb
+++ b/lib/byebug/interfaces/local_interface.rb
@@ -8,9 +8,9 @@ module Byebug
 
     def initialize
       super()
-      @input = STDIN
-      @output = STDOUT
-      @error = STDERR
+      @input = $stdin
+      @output = $stdout
+      @error = $stderr
     end
 
     #

--- a/lib/byebug/interfaces/script_interface.rb
+++ b/lib/byebug/interfaces/script_interface.rb
@@ -6,8 +6,8 @@ module Byebug
     def initialize(file, verbose = false)
       super()
       @input = File.open(file)
-      @output = verbose ? STDOUT : StringIO.new
-      @error = verbose ? STDERR : StringIO.new
+      @output = verbose ? $stdout : StringIO.new
+      @error = verbose ? $stderr : StringIO.new
     end
 
     def read_command(prompt)

--- a/test/interfaces/script_interface_test.rb
+++ b/test/interfaces/script_interface_test.rb
@@ -20,8 +20,8 @@ module Byebug
         interface = ScriptInterface.new(path, true)
 
         assert_instance_of File, interface.input
-        assert_equal STDOUT, interface.output
-        assert_equal STDERR, interface.error
+        assert_equal $stdout, interface.output
+        assert_equal $stderr, interface.error
       end
     end
 


### PR DESCRIPTION
This makes it possible to use http://ruby-doc.org/stdlib-2.0.0/libdoc/minitest/rdoc/MiniTest/Assertions.html#method-i-capture_io to capture the output of byebug in tests (more context: https://github.com/deivid-rodriguez/pry-byebug/pull/90)