### PR TITLE
Fix build failure on "ruby-head" x "CC=clang"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,18 @@ script:
 
 rvm:
   - 2.1.10
+  - 2.1.10-clang
   - 2.2.5
+  - 2.2.5-clang
   - 2.3.1
+  - 2.3.1-clang
   - ruby-head
-
-env:
-  - CC=gcc
-  - CC=clang
+  - ruby-head-clang
 
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: ruby-head-clang
 
 branches:
   only:


### PR DESCRIPTION
"clang: error: unknown argument: '-fexcess-precision=standard'"
occurs when "compiling ../../../../ext/byebug/breakpoint.c".

The reason why compile error occurs is that we use ruby build
by gcc and compile byebug with clang.
"mkmf" uses values of `RbConfig` module which were defined
when ruby is built.

This commit make "env CC" match build information of ruby.

ref: https://github.com/ruby/ruby/blob/v2_3_0/tool/mkconfig.rb