### PR TITLE
Skip to get a line in eval context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master (Unreleased)
 
+### Fixed
+
+* Skip to get a line in eval context (#263).
+
 ## 9.0.1 - 2016-05-14
 
 * `quit` never exiting when remote debugging (#201).

--- a/lib/byebug/helpers/file.rb
+++ b/lib/byebug/helpers/file.rb
@@ -54,7 +54,7 @@ module Byebug
       # True for special files like -e, false otherwise
       #
       def virtual_file?(name)
-        ['(irb)', '-e', '(byebug)'].include?(name)
+        ['(irb)', '-e', '(byebug)', '(eval)'].include?(name)
       end
     end
   end

--- a/test/commands/continue_test.rb
+++ b/test/commands/continue_test.rb
@@ -22,7 +22,8 @@ module Byebug
         13:    b = 5
         14:    c = b + 5
         15:    #{example_class}.new.add_four(c)
-        16:  end
+        16:    eval('c')
+        17:  end
       EOC
     end
 
@@ -75,6 +76,15 @@ module Byebug
         debug_code(program)
 
         check_output_includes "Tracing: #{example_path}:14   c = b + 5"
+      end
+    end
+
+    def test_linetrace_does_not_show_a_line_in_eval_context
+      with_setting :linetrace, true do
+        enter 'cont'
+        debug_code(program)
+
+        check_output_includes 'Tracing: (eval):1'
       end
     end
   end


### PR DESCRIPTION
Fix for test 2 and 3 in https://github.com/deivid-rodriguez/byebug/issues/194.

We can't open a file named "(eval)". So byebug should skip to read its line on linetrace.

