### PR TITLE
Don't stop byebug with linetrace enabled

### DIFF
--- a/ext/byebug/byebug.c
+++ b/ext/byebug/byebug.c
@@ -676,6 +676,9 @@ Stoppable(VALUE self)
   if (post_mortem == Qtrue)
     return Qfalse;
 
+  if (RTEST(tracing))
+    return Qfalse;
+
   context = Current_context(self);
   if (!NIL_P(context))
   {

--- a/test/commands/continue_test.rb
+++ b/test/commands/continue_test.rb
@@ -68,5 +68,14 @@ module Byebug
 
       check_error_includes 'Line 100 is not a valid stopping point in file'
     end
+
+    def test_tracing_after_set_linetrace_and_continue
+      with_setting :linetrace, false do
+        enter 'set linetrace', 'cont'
+        debug_code(program)
+
+        check_output_includes "Tracing: #{example_path}:14   c = b + 5"
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes test 1 of https://github.com/deivid-rodriguez/byebug/issues/194.

We should keep tracepoints enabled to trace lines.