### PR TITLE
Byebug.start_server: yield later, when actual_port is known

### DIFF
--- a/lib/byebug/remote.rb
+++ b/lib/byebug/remote.rb
@@ -36,13 +36,13 @@ module Byebug
 
       start_control(host, port == 0 ? 0 : port + 1)
 
-      yield if block_given?
-
       mutex = Mutex.new
       proceed = ConditionVariable.new
 
       server = TCPServer.new(host, port)
       self.actual_port = server.addr[1]
+
+      yield if block_given?
 
       @thread = DebugThread.new do
         while (session = server.accept)


### PR DESCRIPTION
I didn't find docs or tests for `start_server` taking a block;
not sure how you intended that to be used and whether you'll consider this backward-compatible.

This allows `wait_connection=true` to be meaningfully used with `port=0`.
(If it doesn't return until a client connects,
but a client can't know what port it will listen on,
then here is the only chance to tell the client what port to use.)

My (ab)use case is debugging an app with many background workers.
I wanted to use remote byebug, but I'd have to make each worker listen on a different port, and connect to them all.  (To make things worse, workers are sometimes created/destroyed.)
Instead I wrote this kludge: https://gist.github.com/cben/4d4851f63ded79b74d1cb162422ff13b
which at the breakpoint starts a server and a new terminal with a client that connects to it.
I wanted to avoid manually specified ports with retries on collisions; port=0 is perfect.
But I also wanted wait_connection, which is hard to fake externally as the mutex is not exposed...
With this patch that code could be reduced to something like:
```
def byebug_term
  require 'byebug/core'
  unless Byebug.actual_port
    Byebug.wait_connection = true
    Byebug.start_server('localhost', 0) do  # pick an available port
      system("gnome-terminal -x byebug -R localhost:#{Byebug.actual_port} &")
    end
  end
  Byebug.attach
end
```
