### PR TITLE
Fix enable breakpoint short description

### DIFF
--- a/lib/byebug/commands/enable/breakpoints.rb
+++ b/lib/byebug/commands/enable/breakpoints.rb
@@ -29,7 +29,7 @@ module Byebug
       end
 
       def self.short_description
-        'Disable all or specific breakpoints'
+        'Enable all or specific breakpoints'
       end
 
       def execute


### PR DESCRIPTION
It said "Disable" instead of "Enable".