### PR TITLE
Add templates for Github issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Problem description
+
+Replace this text with a description of the problem you're having. Make
+sure that you're running the latest stable release of both byebug and ruby and
+that the problem you're reporting hasn't been reported (and potentially fixed)
+already.
+
+## Expected behavior
+
+Describe here how you expected byebug to behave in this particular situation.
+
+## Actual behavior
+
+Describe here what actually happened.
+
+## Steps to reproduce the problem
+
+This is extremely important! Providing us with a reliable way to reproduce
+a problem will expedite its solution.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description
+
+Replace this text with a summary of the changes in your PR. Use gramatically
+correct, complete sentences. The more detailed you are, the better. If your PR
+is fixing a specific issue, use [Github's syntax][1] to autoclose the PR on
+merge. Don't use this syntax in specific commit messages, just in the PR's
+description.
+
+## Requirements
+
+Before submitting the PR make sure the following are checked:
+
+* [ ] Wrote [good commit messages][2].
+* [ ] Used the same coding conventions as the rest of the project.
+* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
+* [ ] Squashed related commits together.
+* [ ] All tests are passing.
+* [ ] The PR relates to *only* one subject.
+
+You might also be asked to:
+
+* [ ] Add tests.
+* [ ] Add a Changelog entry if the new code introduces user-observable changes.
+
+[1]: https://github.com/blog/1506-closing-issues-via-pull-requests
+[2]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,1 +1,1 @@
-rules '~MD013,~MD024'
+rules '~MD002,~MD013,~MD024'


### PR DESCRIPTION
There's recently been some friction about how to get changes merged in. Let's add issue and PR templates to try to reduce that.

Credits to the RuboCop project for providing the starting point of these templates. 