### PR TITLE
Add pry as runtime dependency.

### DIFF
--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |s|
   s.extensions = ['ext/byebug/extconf.rb']
   s.require_path = 'lib'
 
+  s.add_runtime_dependency 'pry'
   s.add_development_dependency 'bundler', '~> 1.7'
 end


### PR DESCRIPTION
## Description

This is not issue. But I found that pry was used on below file.
So,  is it possible that we want to add pry as runtime dependency?

```
$ grep -r "require 'pry'" lib/byebug/commands/pry.rb
        require 'pry'
```

## Requirements

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][2].
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] All tests are passing.
* [X] The PR relates to *only* one subject.

You might also be asked to:

* [ ] Add tests.
* [ ] Add a Changelog entry if the new code introduces user-observable changes.
  => Maybe not needed in this case.

[1]: https://github.com/blog/1506-closing-issues-via-pull-requests
[2]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

