### PR TITLE
Fix issue with byebug/core.rb unavailable from class methods

### DIFF
--- a/lib/byebug.rb
+++ b/lib/byebug.rb
@@ -1,1 +1,2 @@
 require 'byebug/attacher'
+require 'byebug/core'

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -1,6 +1,5 @@
 require 'minitest'
 require 'byebug'
-require 'byebug/core'
 require 'byebug/interfaces/test_interface'
 require 'support/utils'
 


### PR DESCRIPTION
## Description

When using byebug from within a class method, I often get an error like this:
```
     NoMethodError:
       undefined method `mode=' for Byebug:Module
     # /Users/markburns/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/byebug-9.0.6/lib/byebug/attacher.rb:13:in `attach'
     # /Users/markburns/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/byebug-9.0.6/lib/byebug/attacher.rb:30:in `byebug'
```

This is because `mode=` is defined in `byebug/core.rb` which is required in `test_helper.rb`.
I think it is important to be as close as possible to the files users will require in running the tests. So I believe this is the correct fix.

However, I am sorry that I do not have the time to work out how to create an isolated test to reproduce the problem (as by definition the test suite has already defined `Byebug.mode=`, hence fixing the issue). 

If you know a good way to test this, other than manually, I'd be happy to have a go at adding one.

I have of course confirmed manually that this fixes the problem.
