### PR TITLE
Fix where command for instance_exec blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Better UI messages for breakpoint management.
 
+### Fixed
+
+* `where` command failing on instance_exec block stack frames
+
 ## 9.0.6 - 2016-09-29
 
 ### Fixed

--- a/lib/byebug/frame.rb
+++ b/lib/byebug/frame.rb
@@ -161,14 +161,14 @@ module Byebug
     def c_args
       return [] unless _self.to_s != 'main'
 
-      _self.method(_method).parameters
+      _class.instance_method(_method).parameters
     end
 
     def ruby_args
       meth_name = _binding.eval('__method__')
       return [] unless meth_name
 
-      meth_obj = _self.method(meth_name)
+      meth_obj = _class.instance_method(meth_name)
       return [] unless meth_obj
 
       meth_obj.parameters

--- a/test/commands/where_test.rb
+++ b/test/commands/where_test.rb
@@ -82,6 +82,34 @@ module Byebug
 
       check_output_includes(*expected_output)
     end
+
+    def test_where_displays_instance_exec_block_frames
+      enter 'where'
+      program = strip_line_numbers <<-EOP
+         1:  module Byebug
+         2:    class #{example_full_class}
+         3:      def foo
+         4:        Object.new.instance_exec do
+         5:          byebug
+         6:        end
+         7:      end
+         8:     end
+         9:
+        10:    #{example_full_class}.new.foo
+        11:  end
+      EOP
+      debug_code(program)
+
+      expected_output = prepare_for_regexp <<-TXT
+        --> #0  block in #{example_full_class}.block in foo at #{example_path}:6
+            #1  BasicObject.instance_exec(*args) at #{example_path}:4
+            #2  #{example_full_class}.foo at #{example_path}:4
+            #3  <module:Byebug> at #{example_path}:10
+            #4  <top (required)> at #{example_path}:1
+      TXT
+
+      check_output_includes(*expected_output)
+    end
   end
 
   #


### PR DESCRIPTION
## Problem

I was getting an error message like the following when using the `where` command

  `*** undefined method `included' for class `SomeController'`

which I managed to track down to a module being mixed into a controller that was using `def self.included` to add a `prepend_around_action` with a block.  I also managed to simplify the test case into the regression test I have added in this PR.

The reason why instance_exec was causing problems is that it calls the block with a different receiver, so `self` in that context won't have the method the block was defined in.

## Solution

Use the frame_class since instance_exec doesn't change it, so the instance method can still be found from the blocks frame.

## Side Notes

* Unhandled exceptions in commands don't result in a stack trace that can easily find where the command failed, which makes bugs like this harder to track down.  The first step of debugging was to figure out where to modify the source code to print the stack trace.
* Byebug::WhereWithNotDeeplyNestedPathsTest#test_where_displays_current_backtrace_w_shorpaths_if_fullpath_disabled was already failing locally on master since it expected full paths starting with `/private/var/folders/4v/` instead of `.../`