### PR TITLE
Drop support for old rubies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
 
 Layout/ExtraSpacing:
   AllowForAlignment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ script:
   - bundle exec codeclimate-test-reporter || test true
 
 rvm:
-  - 2.1.10
-  - 2.1.10-clang
   - 2.2.7
   - 2.2.7-clang
   - 2.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 * `restart` command crashing in certain cases because of a missing `require 'English'` (#321, @akaneko3).
 * `restart` command crashing when debugged script is not executable or has no shebang (#321, @akaneko3).
 
+### Removed
+
+* Ruby 2.0 and Ruby 2.1 official & unofficial support. Byebug no longer installs
+  on these platforms.
+
 ## 9.0.6 - 2016-09-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-* `where` command failing on instance_exec block stack frames
+* `where` command failing on instance_exec block stack frames.
 * `restart` command crashing in certain cases because of a missing `require 'English'` (#321, @akaneko3).
 * `restart` command crashing when debugged script is not executable or has no shebang (#321, @akaneko3).
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@
 [tip_url]: https://gratipay.com/byebug
 [irc_url]: https://gitter.im/deivid-rodriguez/byebug
 
-Byebug is a simple to use, feature rich debugger for Ruby. It uses the new
-TracePoint API for execution control and the new Debug Inspector API for call
-stack navigation, so it doesn't depend on internal core sources. It's developed
-as a C extension, so it's fast. And it has a full test suite so it's reliable.
+Byebug is a simple to use, feature rich debugger for Ruby. It uses the
+TracePoint API for execution control and the Debug Inspector API for call stack
+navigation, so it doesn't depend on internal core sources. It's developed as a C
+extension, so it's fast. And it has a full test suite so it's reliable.
 
 It allows you to see what is going on _inside_ a Ruby program while it executes
 and offers many of the traditional debugging features such as:

--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ Windows [![Vey][vey]][vey_url]
 
 ## Requirements
 
-* Required: MRI 2.0.0 or higher.
 * Recommended:
-  * MRI 2.1.8 or higher.
   * MRI 2.2.4 or higher.
   * MRI 2.3.0 or higher.
   * MRI 2.4.0 or higher.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [tip_url]: https://gratipay.com/byebug
 [irc_url]: https://gitter.im/deivid-rodriguez/byebug
 
-Byebug is a simple to use, feature rich debugger for Ruby 2. It uses the new
+Byebug is a simple to use, feature rich debugger for Ruby. It uses the new
 TracePoint API for execution control and the new Debug Inspector API for call
 stack navigation, so it doesn't depend on internal core sources. It's developed
 as a C extension, so it's fast. And it has a full test suite so it's reliable.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ Windows [![Vey][vey]][vey_url]
 
 ## Requirements
 
-* Required: MRI 2.0.0 or higher. For debugging ruby 1.9.3 or older, use
-  [debugger].
+* Required: MRI 2.0.0 or higher.
 * Recommended:
   * MRI 2.1.8 or higher.
   * MRI 2.2.4 or higher.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,8 @@ environment:
     - ruby_version: 22-x64
     - ruby_version: '23'
     - ruby_version: 23-x64
+    - ruby_version: '24'
+    - ruby_version: 24-x64
 
   codeclimate_repo_token: '02530029b1e956220f05076c590b84b9ab078362c9083312eb2ad
 41cab138408'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,6 @@ test_script:
 
 environment:
   matrix:
-    - ruby_version: '21'
-    - ruby_version: 21-x64
     - ruby_version: '22'
     - ruby_version: 22-x64
     - ruby_version: '23'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,3 @@ notifications:
     on_build_success: false
     on_build_failure: false
     on_build_status_changed: true
-
-    to:
-      - deivid.rodriguez@gmail.com

--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     stack frames among other things and it comes with an easy to use command
     line interface."
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.0'
 
   s.files = Dir['lib/**/*.rb', 'lib/**/*.yml', 'ext/**/*.[ch]', 'LICENSE']
   s.bindir = 'bin'

--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -7,13 +7,12 @@ Gem::Specification.new do |s|
   s.email = 'deivid.rodriguez@mail.com'
   s.license = 'BSD-2-Clause'
   s.homepage = 'http://github.com/deivid-rodriguez/byebug'
-  s.summary = 'Ruby 2.0 fast debugger - base + CLI'
-  s.description = "Byebug is a Ruby 2 debugger. It's implemented using the
-    Ruby 2 TracePoint C API for execution control and the Debug Inspector C API
-    for call stack navigation.  The core component provides support that
-    front-ends can build on. It provides breakpoint handling and bindings for
-    stack frames among other things and it comes with an easy to use command
-    line interface."
+  s.summary = 'Ruby fast debugger - base + CLI'
+  s.description = "Byebug is a Ruby debugger. It's implemented using the
+    TracePoint C API for execution control and the Debug Inspector C API for
+    call stack navigation.  The core component provides support that front-ends
+    can build on. It provides breakpoint handling and bindings for stack frames
+    among other things and it comes with an easy to use command line interface."
 
   s.required_ruby_version = '>= 2.2.0'
 

--- a/lib/byebug/frame.rb
+++ b/lib/byebug/frame.rb
@@ -47,13 +47,10 @@ module Byebug
     #
     # Gets local variables for the frame.
     #
-    # @todo Use `Binding#local_variables` directly once we drop 2.1 support
-    #   since it's a public method since ruby 2.2
-    #
     def locals
       return [] unless _binding
 
-      _binding.eval('local_variables').each_with_object({}) do |e, a|
+      _binding.local_variables.each_with_object({}) do |e, a|
         a[e] = _binding.local_variable_get(e)
         a
       end

--- a/tasks/dev_utils.rb
+++ b/tasks/dev_utils.rb
@@ -62,7 +62,7 @@ end
 desc 'Runs tests continuously'
 task :loop_tests do
   iterations = (ENV['TIMES'] || '8').to_i
-  rubies = ENV['RUBIES'] ? ENV['RUBIES'].split(',') : %w[2.1 2.2 2.3]
+  rubies = ENV['RUBIES'] ? ENV['RUBIES'].split(',') : %w[2.2 2.3]
   ruby_manager = ENV['MANAGER'] || 'chruby'
 
   LoopRunner.new(iterations, rubies, ruby_manager).run

--- a/tasks/dev_utils.rb
+++ b/tasks/dev_utils.rb
@@ -62,7 +62,7 @@ end
 desc 'Runs tests continuously'
 task :loop_tests do
   iterations = (ENV['TIMES'] || '8').to_i
-  rubies = ENV['RUBIES'] ? ENV['RUBIES'].split(',') : %w[2.2 2.3]
+  rubies = ENV['RUBIES'] ? ENV['RUBIES'].split(',') : %w[2.2 2.3 2.4]
   ruby_manager = ENV['MANAGER'] || 'chruby'
 
   LoopRunner.new(iterations, rubies, ruby_manager).run


### PR DESCRIPTION
## Description

This PR drops official & unofficial support for Ruby 2.0 & Ruby 2.1. Supersedes #336.

## Requirements

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][commits].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] All tests are passing.
* [x] The PR relates to *only* one subject.

[commits]: http://chris.beams.io/posts/git-commit
