### PR TITLE
Bump bundler to 1.15.4 in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,4 +95,4 @@ DEPENDENCIES
   yard (= 0.9.9)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4


### PR DESCRIPTION
## Description

This PR bumps the version of bundler in our Gemfile.lock file to 1.15.4.

## Requirements

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][commits].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] All tests are passing.
* [x] The PR relates to *only* one subject.

[commits]: http://chris.beams.io/posts/git-commit
