### PR TITLE
Add travis fast finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ rvm:
   - ruby-head-clang
 
 matrix:
+  fast_finish: true
+
   allow_failures:
     - rvm: ruby-head
     - rvm: ruby-head-clang

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Linux [![Tra][tra]][tra_url]
 
 Windows [![Vey][vey]][vey_url]
 
-[tra]: https://img.shields.io/travis/deivid-rodriguez/byebug.svg?branch=master
+[tra]: https://api.travis-ci.org/deivid-rodriguez/byebug.svg?branch=master
 [vey]: https://ci.appveyor.com/api/projects/status/github/deivid-rodriguez/byebug?svg=true
 
 [tra_url]: https://travis-ci.org/deivid-rodriguez/byebug


### PR DESCRIPTION
## Description

Adds `fast_finish` flag to Travis CI, so PR's get a green or red status faster. Also changes the Travis badge URL since the old one does not get updated instantly, apparently.

## Requirements

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][commits].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] All tests are passing.
* [x] The PR relates to *only* one subject.

[commits]: http://chris.beams.io/posts/git-commit
