### PR TITLE
Fixup the testsuite fails on macOS

### DIFF
--- a/test/commands/where_test.rb
+++ b/test/commands/where_test.rb
@@ -115,9 +115,10 @@ module Byebug
   # nested.
   #
   # @note We skip this tests in Windows since the paths in this CI environment
-  #   are usually very deeply nested.
+  #   are usually very deeply nested and on OS X where tmp path is always
+  #   deeply nested.
   #
-  unless /cygwin|mswin|mingw/ =~ RUBY_PLATFORM
+  unless /cygwin|mswin|mingw|darwin/ =~ RUBY_PLATFORM
     class WhereWithNotDeeplyNestedPathsTest < WhereStandardTest
       def test_where_displays_current_backtrace_w_shorpaths_if_fullpath_disabled
         enter 'set nofullpath', 'where', 'set fullpath'
@@ -143,7 +144,7 @@ module Byebug
   class WhereWithDeeplyNestedPathsTest < WhereStandardTest
     def setup
       @example_parent_folder = Dir.mktmpdir(nil)
-      @example_folder = Dir.mktmpdir(nil, @example_parent_folder)
+      @example_folder = File.realpath(Dir.mktmpdir(nil, @example_parent_folder))
 
       super
     end

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -101,7 +101,7 @@ module Byebug
     # Temporary folder where the test file lives
     #
     def example_folder
-      @example_folder ||= Dir.tmpdir
+      @example_folder ||= File.realpath(Dir.tmpdir)
     end
 
     private


### PR DESCRIPTION
Default tmpdir on macOS is is a symlink pointing somewhere in
`/private/...`.  Because of this in the testsuite we should
always use realpaths since byebug outputs those by default.

Without the fix it is full of failures like https://gist.github.com/bak1an/4f6bdbbadfe96c53bd9d16dd86a87779

The PR also disables `WhereWithNotDeeplyNestedPathsTest` for `darwin` since default `$TMPDIR` on macOS nowadays is something like `/var/folders/5g/s0v3cc2x34ddw3ydhyvkryvr0000gn/T/` (which has realpath `/private/var/folders/5g/s0v3cc2x34ddw3ydhyvkryvr0000gn/T/`). This is the opposite of `not deeply nested` and just fails.