### PR TITLE
Detect timeouts and other test improvements

### DIFF
--- a/script/minitest_runner.rb
+++ b/script/minitest_runner.rb
@@ -19,10 +19,16 @@ class MinitestRunner
 
     flags = ["--name=/#{filtered_methods.join('|')}/", ENV['TESTOPTS']]
 
-    Minitest.run(flags + $ARGV)
+    run_with_timeout(flags)
   end
 
   private
+
+  def run_with_timeout(flags)
+    Timeout.timeout(180) { Minitest.run(flags + $ARGV) }
+  rescue Timeout::Error
+    false
+  end
 
   def runnables
     Minitest::Runnable.runnables

--- a/script/minitest_runner.rb
+++ b/script/minitest_runner.rb
@@ -5,6 +5,7 @@ $LOAD_PATH << File.expand_path(File.join('..', 'test'), __dir__)
 
 require 'minitest'
 require 'English'
+require 'shellwords'
 
 #
 # Helper class to aid running minitest
@@ -17,7 +18,7 @@ class MinitestRunner
   def run
     test_suites.each { |f| require File.expand_path(f) }
 
-    flags = ["--name=/#{filtered_methods.join('|')}/", ENV['TESTOPTS']]
+    flags = ["--name=/#{filtered_methods.join('|')}/", *test_opts]
 
     run_with_timeout(flags)
   end
@@ -36,6 +37,12 @@ class MinitestRunner
 
   def test_suite?(str)
     all_test_suites.include?(str)
+  end
+
+  def test_opts
+    return [] unless ENV['TESTOPTS']
+
+    ENV['TESTOPTS'].shellsplit
   end
 
   def test_suites

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -1,3 +1,5 @@
+require 'minitest/mock'
+
 module Minitest
   #
   # Custom Minitest assertions

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -27,8 +27,6 @@ module Byebug
     def setup
       Byebug.start
       interface.clear
-
-      Byebug.breakpoints.clear if Byebug.breakpoints
     end
 
     #
@@ -37,6 +35,8 @@ module Byebug
     def teardown
       cleanup_namespace
       clear_example_file
+
+      Byebug.breakpoints.clear if Byebug.breakpoints
 
       Byebug.stop
     end

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -37,6 +37,7 @@ module Byebug
       clear_example_file
 
       Byebug.breakpoints.clear if Byebug.breakpoints
+      Byebug.catchpoints.clear if Byebug.catchpoints
 
       Byebug.stop
     end


### PR DESCRIPTION
Currently appveyor build against `ruby-head` deadlocks. That means that we have a bug there, but also that appveyor takes about an hour to send back to green status to GitHub PR's (due to https://github.com/appveyor/ci/issues/1960).

I don't expect byebug test run to ever take longer than 3 minutes, so let's detect those situations and fail early.

This PR also adds some little tweaks to the tests.

Credits to @MSP-Greg for the idea and implementation!