### PR TITLE
~Turn on and~ fix ruby warnings during tests

### DIFF
--- a/test/commands/finish_test.rb
+++ b/test/commands/finish_test.rb
@@ -150,13 +150,13 @@ module Byebug
          1:  autoload :ByebugBar, './byebug_bar'
          2:
          3:  def main
-         4:    ByebugBar
-         5:    'end of main'
+         4:    b = ByebugBar
+         5:    b
          6:  end
          7:
          8:  main
          9:
-        10:  'end of program'
+        10:  sleep 0
       RUBY
     end
 

--- a/test/commands/where_test.rb
+++ b/test/commands/where_test.rb
@@ -93,7 +93,7 @@ module Byebug
          5:          byebug
          6:        end
          7:      end
-         8:     end
+         8:    end
          9:
         10:    #{example_full_class}.new.foo
         11:  end


### PR DESCRIPTION
Not turning warnings on because external gems (`thor`) have warnings and the whole thing seems to abort when that happens on appveyor.