### PR TITLE
Bump rubies on macos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 language: ruby
 
 rvm:
-  - 2.3.5
+  - 2.3.6
   - 2.4.3
   - 2.5.0
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ language: ruby
 rvm:
   - 2.3.5
   - 2.4.3
+  - 2.5.0
   - ruby-head
 
 env:


### PR DESCRIPTION
Supersedes #420 (same with less debug commits and a more adequate branch name).