### PR TITLE
Fix allowed failures incorrectly specified

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,8 +60,10 @@ cache:
 
 matrix:
   allow_failures:
-    - ruby_version: head
+    - ruby_version: head-x86
+      ruby_abi_version: 2.6.0
     - ruby_version: head-x64
+      ruby_abi_version: 2.6.0
 
 branches:
   only:


### PR DESCRIPTION
Appveyor badge is considering ruby-head because (I think) allowed failures are not being properly specified.