### PR TITLE
Rename function to prevent conflict to debase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master (Unreleased)
 
+### Fixed
+
+* Error when using byebug with `debase` gem (#443, @tzmfreedom)
+
 ## 10.0.0 - 2018-01-26
 
 ### Changed

--- a/ext/byebug/byebug.c
+++ b/ext/byebug/byebug.c
@@ -891,7 +891,7 @@ Init_byebug()
   rb_define_module_function(mByebug, "verbose=", Set_verbose, 1);
 
   Init_threads_table(mByebug);
-  Init_context(mByebug);
+  Init_byebug_context(mByebug);
   Init_breakpoint(mByebug);
 
   rb_global_variable(&breakpoints);

--- a/ext/byebug/byebug.h
+++ b/ext/byebug/byebug.h
@@ -125,7 +125,7 @@ extern VALUE next_thread;
 
 /* functions from context.c */
 extern void Init_context(VALUE mByebug);
-extern VALUE context_create(VALUE thread);
+extern VALUE byebug_context_create(VALUE thread);
 extern VALUE context_dup(debug_context_t *context);
 extern void reset_stepping_stop_points(debug_context_t *context);
 extern VALUE call_with_debug_inspector(struct call_with_inspection_data *data);

--- a/ext/byebug/byebug.h
+++ b/ext/byebug/byebug.h
@@ -124,7 +124,7 @@ extern VALUE threads;
 extern VALUE next_thread;
 
 /* functions from context.c */
-extern void Init_context(VALUE mByebug);
+extern void Init_byebug_context(VALUE mByebug);
 extern VALUE byebug_context_create(VALUE thread);
 extern VALUE context_dup(debug_context_t *context);
 extern void reset_stepping_stop_points(debug_context_t *context);

--- a/ext/byebug/context.c
+++ b/ext/byebug/context.c
@@ -642,7 +642,7 @@ dt_inherited(VALUE klass)
  *   Byebug keeps a single instance of this class per thread.
  */
 void
-Init_context(VALUE mByebug)
+Init_byebug_context(VALUE mByebug)
 {
   cContext = rb_define_class_under(mByebug, "Context", rb_cObject);
 

--- a/ext/byebug/context.c
+++ b/ext/byebug/context.c
@@ -56,7 +56,7 @@ dc_stack_size(debug_context_t *context)
 }
 
 extern VALUE
-context_create(VALUE thread)
+byebug_context_create(VALUE thread)
 {
   debug_context_t *context = ALLOC(debug_context_t);
 

--- a/ext/byebug/threads.c
+++ b/ext/byebug/threads.c
@@ -118,7 +118,7 @@ thread_context_lookup(VALUE thread, VALUE *context)
 
   if (!st_lookup(t_tbl->tbl, thread, context) || !*context)
   {
-    *context = context_create(thread);
+    *context = byebug_context_create(thread);
     st_insert(t_tbl->tbl, thread, *context);
   }
 }


### PR DESCRIPTION
When we use byebug and debase gem simultaneously, there are conflict because extern function name is conflict each other.

For example, with byebug and debase gem, if we use `byebug` method to debug code, the following error is occured (this is the same issue as #200 #360 )
```
NoMethodError (undefined method `step_out' for #<Byebug::Context:0x007fa4608278d0>)
```

This is because both gem have extern function `Init_context` and `context_create` and if we call these function in byebug gem, it calls debase's function. (Maybe other development gem use these function name, because `context` is commonly used variable name)

This PR solve by renaming function.