### PR TITLE
Rename functions that conflict with debase's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Error when using byebug with `debase` gem (#447, @tzmfreedom)
+
 ## 10.0.1 - 2018-03-21
 
 ### Fixed

--- a/ext/byebug/breakpoint.c
+++ b/ext/byebug/breakpoint.c
@@ -491,7 +491,7 @@ find_breakpoint_by_method(VALUE breakpoints, VALUE klass, ID mid, VALUE bind,
 }
 
 void
-Init_breakpoint(VALUE mByebug)
+Init_byebug_breakpoint(VALUE mByebug)
 {
   breakpoint_max = 0;
 

--- a/ext/byebug/byebug.c
+++ b/ext/byebug/byebug.c
@@ -244,7 +244,7 @@ call_at_line_check(VALUE ctx, debug_context_t *dc, VALUE breakpoint)
   if (!NIL_P(breakpoint))
     call_at_breakpoint(ctx, dc, breakpoint);
 
-  reset_stepping_stop_points(dc);
+  byebug_reset_stepping_stop_points(dc);
 
   call_at_line(ctx, dc);
 }
@@ -344,7 +344,7 @@ return_event(VALUE trace_point, void *data)
 
   if ((dc->steps_out == 0) && (CTX_FL_TEST(dc, CTX_FL_STOP_ON_RET)))
   {
-    reset_stepping_stop_points(dc);
+    byebug_reset_stepping_stop_points(dc);
 
     call_at_return(context, dc, rb_tracearg_return_value(trace_arg));
   }
@@ -393,7 +393,7 @@ end_event(VALUE trace_point, void *data)
 
   if ((dc->steps_out == 0) && (CTX_FL_TEST(dc, CTX_FL_STOP_ON_RET)))
   {
-    reset_stepping_stop_points(dc);
+    byebug_reset_stepping_stop_points(dc);
 
     call_at_end(context, dc);
   }
@@ -747,7 +747,7 @@ Debug_load(int argc, VALUE *argv, VALUE self)
   if (0 != state)
   {
     status = rb_errinfo();
-    reset_stepping_stop_points(dc);
+    byebug_reset_stepping_stop_points(dc);
   }
 
   return status;
@@ -892,7 +892,7 @@ Init_byebug()
 
   Init_threads_table(mByebug);
   Init_byebug_context(mByebug);
-  Init_breakpoint(mByebug);
+  Init_byebug_breakpoint(mByebug);
 
   rb_global_variable(&breakpoints);
   rb_global_variable(&catchpoints);

--- a/ext/byebug/byebug.h
+++ b/ext/byebug/byebug.h
@@ -107,9 +107,9 @@ typedef struct
 } breakpoint_t;
 
 /* functions from locker.c */
-extern void add_to_locked(VALUE thread);
-extern VALUE pop_from_locked();
-extern void remove_from_locked(VALUE thread);
+extern void byebug_add_to_locked(VALUE thread);
+extern VALUE byebug_pop_from_locked();
+extern void byebug_remove_from_locked(VALUE thread);
 
 /* functions from threads.c */
 extern void Init_threads_table(VALUE mByebug);
@@ -127,13 +127,13 @@ extern VALUE next_thread;
 extern void Init_byebug_context(VALUE mByebug);
 extern VALUE byebug_context_create(VALUE thread);
 extern VALUE context_dup(debug_context_t *context);
-extern void reset_stepping_stop_points(debug_context_t *context);
+extern void byebug_reset_stepping_stop_points(debug_context_t *context);
 extern VALUE call_with_debug_inspector(struct call_with_inspection_data *data);
 extern VALUE context_backtrace_set(const rb_debug_inspector_t *inspector,
                                    void *data);
 
 /* functions from breakpoint.c */
-extern void Init_breakpoint(VALUE mByebug);
+extern void Init_byebug_breakpoint(VALUE mByebug);
 extern VALUE find_breakpoint_by_pos(VALUE breakpoints, VALUE source, VALUE pos,
                                     VALUE bind);
 

--- a/ext/byebug/context.c
+++ b/ext/byebug/context.c
@@ -5,9 +5,9 @@ static VALUE cDebugThread;
 static int thnum_max = 0;
 
 /* "Step", "Next" and "Finish" do their work by saving information about where
- * to stop next. reset_stepping_stop_points removes/resets this information. */
+ * to stop next. byebug_reset_stepping_stop_points removes/resets this information. */
 extern void
-reset_stepping_stop_points(debug_context_t *context)
+byebug_reset_stepping_stop_points(debug_context_t *context)
 {
   context->dest_frame = -1;
   context->lines = -1;
@@ -63,7 +63,7 @@ byebug_context_create(VALUE thread)
   context->flags = 0;
   context->thnum = ++thnum_max;
   context->thread = thread;
-  reset_stepping_stop_points(context);
+  byebug_reset_stepping_stop_points(context);
   context->stop_reason = CTX_STOP_NONE;
 
   rb_debug_inspector_open(context_backtrace_set, (void *)context);
@@ -81,7 +81,7 @@ context_dup(debug_context_t *context)
   debug_context_t *new_context = ALLOC(debug_context_t);
 
   memcpy(new_context, context, sizeof(debug_context_t));
-  reset_stepping_stop_points(new_context);
+  byebug_reset_stepping_stop_points(new_context);
   new_context->backtrace = context->backtrace;
   CTX_FL_SET(new_context, CTX_FL_DEAD);
 

--- a/ext/byebug/locker.c
+++ b/ext/byebug/locker.c
@@ -29,7 +29,7 @@ is_in_locked(VALUE thread)
 }
 
 extern void
-add_to_locked(VALUE thread)
+byebug_add_to_locked(VALUE thread)
 {
   locked_thread_t *node;
 
@@ -50,7 +50,7 @@ add_to_locked(VALUE thread)
 }
 
 extern VALUE
-pop_from_locked()
+byebug_pop_from_locked()
 {
   VALUE thread;
   locked_thread_t *node;
@@ -71,7 +71,7 @@ pop_from_locked()
 }
 
 extern void
-remove_from_locked(VALUE thread)
+byebug_remove_from_locked(VALUE thread)
 {
   locked_thread_t *node;
   locked_thread_t *next_node;
@@ -81,7 +81,7 @@ remove_from_locked(VALUE thread)
 
   if (locked_head->thread == thread)
   {
-    pop_from_locked();
+    byebug_pop_from_locked();
     return;
   }
 

--- a/ext/byebug/threads.c
+++ b/ext/byebug/threads.c
@@ -134,7 +134,7 @@ acquire_lock(debug_context_t *dc)
   while ((!NIL_P(locker) && locker != rb_thread_current())
          || CTX_FL_TEST(dc, CTX_FL_SUSPEND))
   {
-    add_to_locked(rb_thread_current());
+    byebug_add_to_locked(rb_thread_current());
     rb_thread_stop();
 
     if (CTX_FL_TEST(dc, CTX_FL_SUSPEND))
@@ -159,10 +159,10 @@ release_lock(void)
   locker = Qnil;
 
   if (NIL_P(next_thread))
-    thread = pop_from_locked();
+    thread = byebug_pop_from_locked();
   else
   {
-    remove_from_locked(next_thread);
+    byebug_remove_from_locked(next_thread);
     thread = next_thread;
     next_thread = Qnil;
   }


### PR DESCRIPTION
On my last pullrequest (#443), I fixed conflict with debase by renaming context initializer functions(e.g. Init_context() => Init_byebug_context()).

But I missed to fix other functions to conflict with debase's, for example Init_breakpoint(). So breakpoint isn't worked when using with debase.

I fixed it on this PR. On this PR, we can use byebug with debase completely.

Fixed point(rename) is the following

* Init_breakpoint() => Init_byebug_breakpoint()
  * conflict to https://github.com/denofevil/debase/blob/c317d87bcf48a66f25da858a9ab6d7f4c5486ee7/ext/debase_internals.h#L110
* reset_stepping_stop_points() => byebug_reset_stepping_stop_points()
  * conflict to https://github.com/denofevil/debase/blob/c317d87bcf48a66f25da858a9ab6d7f4c5486ee7/ext/debase_internals.h#L79
* add_to_locked() => byebug_add_to_locked()
* pop_from_locked() => byebug_pop_from_locked()
* remove_from_locked() => byebug_remove_from_locked()
  * conflict to https://github.com/denofevil/debase/blob/c317d87bcf48a66f25da858a9ab6d7f4c5486ee7/ext/debase_internals.h#L93-L95

I think extern function name is unique globally as much as possible because C doesn't have namespace to function name.
For example, on msgpack-ruby(https://github.com/msgpack/msgpack-ruby), there is some functions that is prefixed with `MessagePack` or `msgpack`.

So ideally we may rename all extern function name by adding prefix(e.g. byebug_xxx()).
But I fixed only functions that conflict with debase now.
(I don't know the reason, some functions is the same as debase's.)