### PR TITLE
Remove codeclimate for linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ steps: &steps
     - save_cache:
         key: dependencies-{{ checksum "Gemfile.lock" }}
         paths:
-          - .vendor/bundle
+          - .bundle
 
 jobs:
   prior-to-prior-to-latest-readline-gcc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ steps: &steps
           - dependencies-{{ checksum "Gemfile.lock" }}
 
     - run:
-        name: Run CI checks
-        command: bin/ci.sh
+        name: Run tests
+        command: bin/test.sh
 
     - run:
         name: Save coverage
@@ -29,6 +29,26 @@ steps: &steps
           - .bundle
 
 jobs:
+  lint:
+    docker:
+      - image: deividrodriguez/byebug:2.5.1-readline-clang
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - dependencies-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: Run linters
+          command: bin/lint.sh
+
+      - save_cache:
+          key: dependencies-{{ checksum "Gemfile.lock" }}
+          paths:
+            - .bundle
+
   prior-to-prior-to-latest-readline-gcc:
     docker:
       - image: deividrodriguez/byebug:2.3.7-readline-gcc
@@ -112,20 +132,55 @@ workflows:
 
   test:
     jobs:
-      - prior-to-prior-to-latest-readline-gcc
-      - prior-to-prior-to-latest-libedit-gcc
-      - prior-to-prior-to-latest-readline-clang
-      - prior-to-prior-to-latest-libedit-clang
+      - lint
 
-      - prior-to-latest-readline-gcc
-      - prior-to-latest-libedit-gcc
-      - prior-to-latest-readline-clang
-      - prior-to-latest-libedit-clang
+      - prior-to-prior-to-latest-readline-gcc:
+          requires:
+            - lint
 
-      - latest-readline-gcc
-      - latest-libedit-gcc
-      - latest-readline-clang
-      - latest-libedit-clang
+      - prior-to-prior-to-latest-libedit-gcc:
+          requires:
+            - lint
+
+      - prior-to-prior-to-latest-readline-clang:
+          requires:
+            - lint
+
+      - prior-to-prior-to-latest-libedit-clang:
+          requires:
+            - lint
+
+      - prior-to-latest-readline-gcc:
+          requires:
+            - lint
+
+      - prior-to-latest-libedit-gcc:
+          requires:
+            - lint
+
+      - prior-to-latest-readline-clang:
+          requires:
+            - lint
+
+      - prior-to-latest-libedit-clang:
+          requires:
+            - lint
+
+      - latest-readline-gcc:
+          requires:
+            - lint
+
+      - latest-libedit-gcc:
+          requires:
+            - lint
+
+      - latest-readline-clang:
+          requires:
+            - lint
+
+      - latest-libedit-clang:
+          requires:
+            - lint
 
       - upload_coverage:
           requires:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,21 +23,6 @@ checks:
     enabled: false
 
 plugins:
-  grep:
-    enabled: true
-
-    config:
-      patterns:
-        no-trailing-whitespace:
-          pattern: \s*$
-          annotation: "Don't leave trailing whitespace"
-          severity: minor
-          categories: Style
-          path_patterns:
-            - .rubocop.yml
-            - .rubocop_todo.yml
-            - .travis.yml
-
   shellcheck:
     enabled: true
 

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -38,16 +38,6 @@ plugins:
             - .rubocop_todo.yml
             - .travis.yml
 
-        no-tabs:
-          pattern: "	"
-          annotation: "Don't use hard tabs"
-          severity: minor
-          categories: Style
-          path_patterns:
-            - .rubocop.yml
-            - .rubocop_todo.yml
-            - .travis.yml
-
   shellcheck:
     enabled: true
 

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -22,10 +22,6 @@ checks:
   similar-code:
     enabled: false
 
-plugins:
-  shellcheck:
-    enabled: true
-
 exclude_patterns:
   - .bundle/
   - coverage/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,23 +3,34 @@
 version: "2"
 
 checks:
+  argument-count:
+    enabled: false
+
+  complex-logic:
+    enabled: false
+
   file-lines:
-    config:
-      threshold: 370
+    enabled: false
 
   method-complexity:
-    config:
-      threshold: 13
+    enabled: false
 
   method-count:
-    config:
-      threshold: 25
+    enabled: false
+
+  method-lines:
+    enabled: false
+
+  nested-control-flow:
+    enabled: false
 
   return-statements:
-    config:
-      threshold: 5
+    enabled: false
 
   similar-code:
+    enabled: false
+
+  identical-code:
     enabled: false
 
 exclude_patterns:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
     fi
 
 script:
-  - bin/ci.sh
+  - bin/test.sh
 
 matrix:
   fast_finish: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,20 +43,8 @@ abide by its terms.
 
 ## Code style
 
-* Byebug uses [codeclimate][] to enforce code style. You can run codeclimate
-  checks locally using the [codeclimate CLI][] with `codeclimate analyze`.
-
-* It also uses some extra style checks that are not available in codeclimate.
-  You can run those using `bin/rake lint`. These tasks are:
-
-  * Linting of c-files using `clang-format`. Configuration is specific to
-    clang-format 3.8, you may need some extra work to get that installed on macOS,
-    see below.
-
-  * Checking correct executable bit on repository files.
-
-[codeclimate]: https://codeclimate.com/github/deivid-rodriguez/byebug
-[codeclimate CLI]: https://github.com/codeclimate/codeclimate
+* Byebug uses several style checks to check code style consistent. You can run
+  those using `bin/rake lint`.
 
 ### Runnning `clang-format` on macOS
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@
 [![Gitter][irc]][irc_url]
 
 [gem]: https://img.shields.io/gem/v/byebug.svg
-[mai]: https://api.codeclimate.com/v1/badges/f1a1bec582752c22da80/maintainability
 [cov]: https://api.codeclimate.com/v1/badges/f1a1bec582752c22da80/test_coverage
 [irc]: https://img.shields.io/badge/IRC%20(gitter)-devs%20%26%20users-brightgreen.svg
 
 [gem_url]: https://rubygems.org/gems/byebug
-[mai_url]: https://codeclimate.com/github/deivid-rodriguez/byebug/maintainability
 [cov_url]: https://codeclimate.com/github/deivid-rodriguez/byebug/test_coverage
 [irc_url]: https://gitter.im/deivid-rodriguez/byebug
 

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ end
 
 namespace :lint do
   desc "Run all linters"
-  task all: %i[clang_format executables rubocop mdl]
+  task all: %i[clang_format executables tabs rubocop mdl]
 
   require_relative "tasks/linter"
 
@@ -54,6 +54,13 @@ namespace :lint do
     puts "Checking for unnecessary executables"
 
     ExecutableLinter.new.run
+  end
+
+  desc "Check for tabs"
+  task :tabs do
+    puts "Checking for unnecessary tabs"
+
+    TabLinter.new.run
   end
 
   require "rubocop/rake_task"

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ end
 
 namespace :lint do
   desc "Run all linters"
-  task all: %i[clang_format executables tabs rubocop mdl]
+  task all: %i[clang_format executables tabs trailing_whitespace rubocop mdl]
 
   require_relative "tasks/linter"
 
@@ -61,6 +61,13 @@ namespace :lint do
     puts "Checking for unnecessary tabs"
 
     TabLinter.new.run
+  end
+
+  desc "Check for trailing whitespace"
+  task :trailing_whitespace do
+    puts "Checking for unnecessary trailing whitespace"
+
+    TrailingWhitespaceLinter.new.run
   end
 
   require "rubocop/rake_task"

--- a/Rakefile
+++ b/Rakefile
@@ -80,6 +80,13 @@ namespace :lint do
 
     abort unless system("mdl", *Dir.glob("*.md"))
   end
+
+  desc "Checks shell code style with shellcheck"
+  task :shellcheck do
+    puts "Running shellcheck"
+
+    abort unless system("shellcheck", *Dir.glob("bin/*.sh"))
+  end
 end
 
 desc "Runs lint tasks not available on codeclimate"

--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,7 @@ namespace :lint do
 
   desc "Checks markdown code style with Markdownlint"
   task :mdl do
-    puts "Running mdl..."
+    puts "Running mdl"
 
     abort unless system("mdl", *Dir.glob("*.md"))
   end

--- a/Rakefile
+++ b/Rakefile
@@ -89,7 +89,7 @@ namespace :lint do
   end
 end
 
-desc "Runs lint tasks not available on codeclimate"
+desc "Runs lint tasks"
 task lint: "lint:all"
 
 namespace :docker do

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ end
 
 namespace :lint do
   desc "Run all linters"
-  task all: %i[clang_format unnecessary_executables rubocop mdl]
+  task all: %i[clang_format executables rubocop mdl]
 
   require_relative "tasks/linter"
 
@@ -50,7 +50,7 @@ namespace :lint do
   end
 
   desc "Check unnecessary execute permissions"
-  task :unnecessary_executables do
+  task :executables do
     puts "Checking for unnecessary executables"
 
     ExecutableLinter.new.run

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 set +x
 
 bin/bundle install --jobs 3 --retry 3 --path .bundle

--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -5,6 +5,6 @@ set -eo pipefail
 set +x
 
 bin/bundle install --jobs 3 --retry 3 --path .bundle
-bin/rake
+bin/rake lint
 
 set -x

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+set +x
+
+bin/bundle install --jobs 3 --retry 3 --path .bundle
+bin/rake compile test
+
+set -x

--- a/tasks/linter.rb
+++ b/tasks/linter.rb
@@ -93,3 +93,18 @@ class TabLinter
     file == relative_path || !File.read(file, encoding: Encoding::UTF_8).include?("	")
   end
 end
+
+#
+# Checks trailing whitespace
+#
+class TrailingWhitespaceLinter
+  include LinterMixin
+
+  def applicable_files
+    Open3.capture2("git ls-files")[0].split
+  end
+
+  def clean?(file)
+    !File.read(file, encoding: Encoding::UTF_8).match?(/ +$/)
+  end
+end

--- a/tasks/linter.rb
+++ b/tasks/linter.rb
@@ -76,3 +76,20 @@ class ExecutableLinter
     (in_exec_folder && executable) || (!in_exec_folder && !executable)
   end
 end
+
+#
+# Checks no tabs in source code
+#
+class TabLinter
+  include LinterMixin
+
+  def applicable_files
+    Open3.capture2("git ls-files")[0].split
+  end
+
+  def clean?(file)
+    relative_path = Pathname.new(__FILE__).relative_path_from(Pathname.new(File.dirname(__dir__))).to_s
+
+    file == relative_path || !File.read(file, encoding: Encoding::UTF_8).include?("	")
+  end
+end


### PR DESCRIPTION
So we can keep all linters in a single place and have more control over them. Also, this will make a potential future migration to Gitlab easier.