### PR TITLE
Add basic SimpleCov configurations

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
-require "simplecov" if ENV["NOCOV"].nil?
+if ENV["NOCOV"].nil?
+  require "simplecov"
+  
+  SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+  SimpleCov.start do
+    add_filter ['test']
+  end
+end
+
 require "support/test_case"
 
 Byebug::TestCase.before_suite

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,10 +2,10 @@
 
 if ENV["NOCOV"].nil?
   require "simplecov"
-  
+
   SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
   SimpleCov.start do
-    add_filter ['test']
+    add_filter "test"
   end
 end
 


### PR DESCRIPTION
- Remove `/test` from local reports. When opening the `coverage/index.html` in my browser, I could see the test folder there
- Add HTML formatter