### PR TITLE
Drop 2.2 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Layout/ExtraSpacing:
   AllowForAlignment: false
@@ -24,10 +24,6 @@ Naming/FileName:
 
 TrivialAccessors:
   ExactNameMatch: true
-
-# Until we bump TargetRubyVersion to 2.3
-Style/FrozenStringLiteralComment:
-  EnforcedStyle: always
 
 Style/ModuleFunction:
   EnforcedStyle: extend_self

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+* Support for MRI 2.2. Byebug no longer installs on this platform.
+
 ## [10.0.2] - 2018-03-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ Windows [![Vey][vey]][vey_url]
 
 ## Requirements
 
-* Required: MRI 2.2.0 or higher.
-
-* Recommended: MRI 2.3.0 or higher.
+MRI 2.3.0 or higher.
 
 ## Install
 

--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     can build on. It provides breakpoint handling and bindings for stack frames
     among other things and it comes with an easy to use command line interface."
 
-  s.required_ruby_version = ">= 2.2.0"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.files = Dir["lib/**/*.rb", "lib/**/*.yml", "ext/**/*.[ch]", "LICENSE"]
   s.bindir = "exe"

--- a/lib/byebug/commands/break.rb
+++ b/lib/byebug/commands/break.rb
@@ -76,7 +76,7 @@ module Byebug
     def target_object(str)
       k = error_eval(str)
 
-      k && k.is_a?(Module) ? k.name : str
+      k&.is_a?(Module) ? k.name : str
     rescue StandardError
       errmsg("Warning: breakpoint source is not yet defined")
       str

--- a/lib/byebug/commands/info/breakpoints.rb
+++ b/lib/byebug/commands/info/breakpoints.rb
@@ -57,7 +57,7 @@ module Byebug
         )
         puts interp
         hits = brkpt.hit_count
-        return unless hits > 0
+        return unless hits.positive?
 
         s = hits > 1 ? "s" : ""
         puts "  breakpoint already hit #{hits} time#{s}"

--- a/lib/byebug/helpers/frame.rb
+++ b/lib/byebug/helpers/frame.rb
@@ -21,7 +21,7 @@ module Byebug
 
       def adjust_frame(new_frame)
         return frame_err("too_low") if new_frame >= context.stack_size
-        return frame_err("too_high") if new_frame < 0
+        return frame_err("too_high") if new_frame.negative?
 
         context.frame = new_frame
         processor.prev_line = nil

--- a/lib/byebug/helpers/string.rb
+++ b/lib/byebug/helpers/string.rb
@@ -25,9 +25,6 @@ module Byebug
       #
       # Removes a number of leading whitespace for each input line.
       #
-      # @note Might be unnecessary when Ruby 2.2 support is dropped and we can
-      # use squiggly heredoc's.
-      #
       def deindent(str, leading_spaces: 6)
         str.gsub(/^ {#{leading_spaces}}/, "")
       end

--- a/lib/byebug/interfaces/local_interface.rb
+++ b/lib/byebug/interfaces/local_interface.rb
@@ -5,7 +5,7 @@ module Byebug
   # Interface class for standard byebug use.
   #
   class LocalInterface < Interface
-    EOF_ALIAS = "continue".freeze
+    EOF_ALIAS = "continue"
 
     def initialize
       super()

--- a/lib/byebug/printers/base.rb
+++ b/lib/byebug/printers/base.rb
@@ -11,7 +11,7 @@ module Byebug
       class MissedPath < StandardError; end
       class MissedArgument < StandardError; end
 
-      SEPARATOR = ".".freeze
+      SEPARATOR = "."
 
       def type
         self.class.name.split("::").last.downcase
@@ -23,7 +23,7 @@ module Byebug
         result = nil
         contents.each_value do |contents|
           result = parts(path).reduce(contents) do |r, part|
-            r && r.key?(part) ? r[part] : nil
+            r&.key?(part) ? r[part] : nil
           end
           break if result
         end

--- a/lib/byebug/settings/callstyle.rb
+++ b/lib/byebug/settings/callstyle.rb
@@ -7,7 +7,7 @@ module Byebug
   # Setting to customize the verbosity level for stack frames.
   #
   class CallstyleSetting < Setting
-    DEFAULT = "long".freeze
+    DEFAULT = "long"
 
     def banner
       "Set how you want method call parameters to be displayed"

--- a/lib/byebug/version.rb
+++ b/lib/byebug/version.rb
@@ -4,5 +4,5 @@
 # Reopen main module to define the library version
 #
 module Byebug
-  VERSION = "10.0.2".freeze
+  VERSION = "10.0.2"
 end

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -38,8 +38,8 @@ module Byebug
       cleanup_namespace
       clear_example_file
 
-      Byebug.breakpoints.clear if Byebug.breakpoints
-      Byebug.catchpoints.clear if Byebug.catchpoints
+      Byebug.breakpoints&.clear
+      Byebug.catchpoints&.clear
 
       Byebug.stop
     end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -61,7 +61,7 @@ module Byebug
     def debug_code(program, &block)
       interface.test_block = block
       debug_in_temp_file(program)
-      interface.test_block.call if interface.test_block
+      interface.test_block&.call
     end
 
     #


### PR DESCRIPTION
I stopped testing on MRI 2.2 a while ago. Now I'm officially dropping support by preventing installation under that ruby.