### PR TITLE
Remove force_ruby_platform setting from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,6 @@ install:
   - gem update --system 2.7.8
   - gem install bundler --version 1.17.1 --force
 
-  - bundle config force_ruby_platform true
   - bundle install --jobs 3 --retry 3 --path .bundle
 
 build_script:


### PR DESCRIPTION
I don't think it's necessary now, and it causes issues when adding dependencies.