### PR TITLE
Make `program_with_two_breakpoints` has exactly 2 breakpoints

### DIFF
--- a/test/remote_debugging_test.rb
+++ b/test/remote_debugging_test.rb
@@ -55,13 +55,12 @@ module Byebug
         16:
         17:    byebug
         18:    thingy = #{example_class}.new
-        19:    byebug
-        20:    thingy.a
-        21:    sleep 3
-        22:    thingy.a
-        23:    byebug
-        24:    thingy.a
-        25:  end
+        19:    thingy.a
+        20:    sleep 3
+        21:    thingy.a
+        22:    byebug
+        23:    thingy.a
+        24:  end
       RUBY
     end
 


### PR DESCRIPTION
This test case was introduced as a regression test of
https://github.com/deivid-rodriguez/byebug/issues/274
in https://github.com/deivid-rodriguez/byebug/pull/406.

The description of issues/274 says an exception will be raised
if the byebug CLI is terminated when main program is sleeping.

Before this commit there are 2 breakpoints (`byebug` method call)
before `sleep 3` and `"cont"` is called once because the arugment of
`remote_debug_connect_and_interrupt` is `"cont"`.
I think this is not intended.

And the method name of test case is `program_with_two_breakpoints`,
on the other hand the program had 3 breakpoints (`byebug`).