### PR TITLE
Improve `break` help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* [#527](https://github.com/deivid-rodriguez/byebug/pull/527): `break` help text to clarify placeholders from literals.
+
 ### Removed
 
 * Support for MRI 2.2. Byebug no longer installs on this platform.

--- a/lib/byebug/commands/break.rb
+++ b/lib/byebug/commands/break.rb
@@ -23,8 +23,8 @@ module Byebug
 
     def self.description
       <<-DESCRIPTION
-        b[reak] [file:]line [if expr]
-        b[reak] [module::...]class(.|#)method [if expr]
+        b[reak] [<file>:]<line> [if <expr>]
+        b[reak] [<module>::...]<class>(.|#)<method> [if <expr>]
 
         They can be specified by line or method and an expression can be added
         for conditionally enabled breakpoints.

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -340,7 +340,7 @@ module Byebug
       enter "break", "cont"
       debug_code(program)
 
-      check_output_includes(/b\[reak\] \[file:\]line \[if expr\]/)
+      check_output_includes(/b\[reak\] \[<file>:\]<line> \[if <expr>\]/)
     end
 
     def test_setting_breakpoint_uses_new_source

--- a/test/commands/help_test.rb
+++ b/test/commands/help_test.rb
@@ -86,8 +86,8 @@ module Byebug
       debug_code(minimal_program)
 
       expected_output = split_lines <<-TXT
-        b[reak] [file:]line [if expr]
-        b[reak] [module::...]class(.|#)method [if expr]
+        b[reak] [<file>:]<line> [if <expr>]
+        b[reak] [<module>::...]<class>(.|#)<method> [if <expr>]
 
         Sets breakpoints in the source code
       TXT


### PR DESCRIPTION
Use "<" and ">" for placeholders.