### PR TITLE
Improve `quit` help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * [#527](https://github.com/deivid-rodriguez/byebug/pull/527): `break` help text to clarify placeholders from literals.
+* [#528](https://github.com/deivid-rodriguez/byebug/pull/528): `quit!` help to not show a space between "quit" and "!".
 
 ### Removed
 

--- a/lib/byebug/commands/quit.rb
+++ b/lib/byebug/commands/quit.rb
@@ -20,8 +20,8 @@ module Byebug
 
         #{short_description}
 
-        Normally we prompt before exiting. However if the parameter
-        "unconditionally" is given or command is suffixed with !, we exit
+        Normally we prompt before exiting. However, if the parameter
+        "unconditionally" is given or command is suffixed with "!", we exit
         without asking further questions.
       DESCRIPTION
     end

--- a/lib/byebug/commands/quit.rb
+++ b/lib/byebug/commands/quit.rb
@@ -16,7 +16,7 @@ module Byebug
 
     def self.description
       <<-DESCRIPTION
-        q[uit] [!|unconditionally]
+        q[uit][!| unconditionally]
 
         #{short_description}
 


### PR DESCRIPTION
* The `quit!` variation does not use a space between `quit` and `!`.
* Improve the help copy.