### PR TITLE
Add irb as a runtime dependency

### DIFF
--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -29,5 +29,7 @@ Gem::Specification.new do |s|
   s.extensions = ["ext/byebug/extconf.rb"]
   s.require_path = "lib"
 
+  s.add_runtime_dependency "irb", "~> 1.0"
+
   s.add_development_dependency "bundler", "~> 2.0"
 end


### PR DESCRIPTION
prybug depends on irb: https://github.com/deivid-rodriguez/byebug/blob/d971a2b40807faf4c8654b204ddc2b30d90351fe/lib/byebug/commands/irb.rb#L4
irb isn't bundled with ruby, starting with ruby2.6. irb is a standalone
gem, so we cannot rely on it being present on the target system.