### PR TITLE
Fix `skip` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * [#546](https://github.com/deivid-rodriguez/byebug/pull/546): `continue!` to ignore further `byebug` calls.
+* [#545](https://github.com/deivid-rodriguez/byebug/pull/545): `skip` autolisting code for intermediate skipped breakpoints.
 
 ## [11.0.0] - 2019-02-15
 

--- a/lib/byebug/commands/skip.rb
+++ b/lib/byebug/commands/skip.rb
@@ -13,6 +13,7 @@ module Byebug
 
     class << self
       attr_writer :file_line, :file_path
+      attr_reader :previous_autolist
 
       def file_line
         @file_line ||= 0
@@ -62,6 +63,7 @@ module Byebug
 
     def reset_attributes
       self.class.always_run = 0
+      ListCommand.new(processor).execute if self.class.previous_autolist == 1
       self.class.restore_autolist
     end
 

--- a/lib/byebug/commands/skip.rb
+++ b/lib/byebug/commands/skip.rb
@@ -41,6 +41,7 @@ module Byebug
 
     def initialize_attributes
       self.class.always_run = 2
+      ListCommand.always_run = 0
       self.class.file_path = frame.file
       self.class.file_line = frame.line
     end
@@ -51,6 +52,7 @@ module Byebug
 
     def reset_attributes
       self.class.always_run = 0
+      ListCommand.always_run = 1
     end
 
     def auto_run

--- a/lib/byebug/commands/skip.rb
+++ b/lib/byebug/commands/skip.rb
@@ -21,6 +21,16 @@ module Byebug
       def file_path
         @file_path ||= ""
       end
+
+      def setup_autolist(value)
+        @previous_autolist = ListCommand.always_run
+        ListCommand.always_run = value
+      end
+
+      def restore_autolist
+        ListCommand.always_run = @previous_autolist
+        @previous_autolist = nil
+      end
     end
 
     def self.regexp
@@ -41,7 +51,7 @@ module Byebug
 
     def initialize_attributes
       self.class.always_run = 2
-      ListCommand.always_run = 0
+      self.class.setup_autolist(0)
       self.class.file_path = frame.file
       self.class.file_line = frame.line
     end
@@ -52,7 +62,7 @@ module Byebug
 
     def reset_attributes
       self.class.always_run = 0
-      ListCommand.always_run = 1
+      self.class.restore_autolist
     end
 
     def auto_run

--- a/test/commands/skip_test.rb
+++ b/test/commands/skip_test.rb
@@ -50,6 +50,7 @@ module Byebug
 
       check_output_includes "=> 10:         i *= new_number"
       check_output_doesnt_include "=> 10:         i *= new_number", "=> 10:         i *= new_number"
+      check_output_includes "=> 17:   sleep 0"
     end
 
     def test_restores_previous_autolisting_after_skip

--- a/test/commands/skip_test.rb
+++ b/test/commands/skip_test.rb
@@ -17,8 +17,8 @@ module Byebug
          6:      def factor(num)
          7:        i = 1
          8:        num.times do |new_number|
-         9:          i *= new_number
-        10:          byebug
+         9:          byebug
+        10:          i *= new_number
         11:        end
         12:      end
         13:    end

--- a/test/commands/skip_test.rb
+++ b/test/commands/skip_test.rb
@@ -25,8 +25,9 @@ module Byebug
         14:    c = 5
         15:
         16:    result = #{example_class}.new.factor(c)
-        17:    "Result is: " + result.to_s
-        18:  end
+        17:    sleep 0
+        18:    "Result is: " + result.to_s
+        19:  end
       RUBY
     end
 
@@ -49,6 +50,16 @@ module Byebug
 
       check_output_includes "=> 10:         i *= new_number"
       check_output_doesnt_include "=> 10:         i *= new_number", "=> 10:         i *= new_number"
+    end
+
+    def test_restores_previous_autolisting_after_skip
+      with_setting :autolist, false do
+        enter "break 17", "skip", "continue 18"
+
+        debug_code(program)
+
+        check_output_doesnt_include '=> 18:   "Result is: " + result.to_s'
+      end
     end
   end
 end

--- a/test/commands/skip_test.rb
+++ b/test/commands/skip_test.rb
@@ -41,5 +41,14 @@ module Byebug
 
       debug_code(program) { assert_location example_path, 17 }
     end
+
+    def test_does_not_list_code_for_intermediate_breakpoints
+      enter "break 17", "skip"
+
+      debug_code(program)
+
+      check_output_includes "=> 10:         i *= new_number"
+      check_output_doesnt_include "=> 10:         i *= new_number", "=> 10:         i *= new_number"
+    end
   end
 end


### PR DESCRIPTION
The new `skip` command was autolisting code for intermediate skipped breakpoints.

### Before

```
[1, 9] in /home/deivid/Code/byebug/sum.rb
   1: sum = 0
   2: 
   3: 2.times do |i|
   4:   byebug
=> 5:   sum += i
   6: end
   7: 
   8: byebug
   9: puts "Sum is #{sum}"
(byebug) skip

[1, 9] in /home/deivid/Code/byebug/sum.rb
   1: sum = 0
   2: 
   3: 2.times do |i|
   4:   byebug
=> 5:   sum += i
   6: end
   7: 
   8: byebug
   9: puts "Sum is #{sum}"

[1, 9] in /home/deivid/Code/byebug/sum.rb
   1: sum = 0
   2: 
   3: 2.times do |i|
   4:   byebug
   5:   sum += i
   6: end
   7: 
   8: byebug
=> 9: puts "Sum is #{sum}"
(byebug)
```

### After 

```
[1, 9] in /home/deivid/Code/byebug/sum.rb
   1: sum = 0
   2: 
   3: 2.times do |i|
   4:   byebug
=> 5:   sum += i
   6: end
   7: 
   8: byebug
   9: puts "Sum is #{sum}"
(byebug) skip

[1, 9] in /home/deivid/Code/byebug/sum.rb
   1: sum = 0
   2: 
   3: 2.times do |i|
   4:   byebug
   5:   sum += i
   6: end
   7: 
   8: byebug
=> 9: puts "Sum is #{sum}"
(byebug) 
```