### PR TITLE
Fix `continue!` with byebug calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* [#546](https://github.com/deivid-rodriguez/byebug/pull/546): `continue!` to ignore further `byebug` calls.
+
 ## [11.0.0] - 2019-02-15
 
 ### Added

--- a/lib/byebug/attacher.rb
+++ b/lib/byebug/attacher.rb
@@ -35,7 +35,7 @@ end
 #
 module Kernel
   def byebug
-    Byebug.attach
+    Byebug.attach unless Byebug.mode == :off
   end
 
   def remote_byebug(host = "localhost", port = nil)

--- a/lib/byebug/attacher.rb
+++ b/lib/byebug/attacher.rb
@@ -8,8 +8,6 @@ module Byebug
   # Starts byebug, and stops at the first line of user's code.
   #
   def self.attach
-    require "byebug/core"
-
     unless started?
       self.mode = :attached
 
@@ -35,6 +33,8 @@ end
 #
 module Kernel
   def byebug
+    require "byebug/core"
+
     Byebug.attach unless Byebug.mode == :off
   end
 

--- a/lib/byebug/commands/continue.rb
+++ b/lib/byebug/commands/continue.rb
@@ -47,6 +47,7 @@ module Byebug
 
       processor.proceed!
 
+      Byebug.mode = :off if unconditionally?
       Byebug.stop if unconditionally? || Byebug.stoppable?
     end
 

--- a/lib/byebug/core.rb
+++ b/lib/byebug/core.rb
@@ -36,6 +36,7 @@ module Byebug
   #
   # * :attached => Attached to a running program through the `byebug` method.
   # * :standalone => Started through `byebug` script.
+  # * :off => Ignoring any `byebug` method calls.
   #
   attr_accessor :mode
 

--- a/test/commands/continue_test.rb
+++ b/test/commands/continue_test.rb
@@ -36,15 +36,19 @@ module Byebug
     end
 
     def test_continues_until_the_end_if_used_with_bang
-      enter "break 14", "continue!"
+      with_mode(:attached) do
+        enter "break 14", "continue!"
 
-      debug_code(program) { assert_program_finished }
+        debug_code(program) { assert_program_finished }
+      end
     end
 
     def test_continues_until_the_end_if_used_with_unconditionally
-      enter "break 14", "continue unconditionally"
+      with_mode(:attached) do
+        enter "break 14", "continue unconditionally"
 
-      debug_code(program) { assert_program_finished }
+        debug_code(program) { assert_program_finished }
+      end
     end
 
     def test_stops_byebug_after_continue
@@ -99,6 +103,40 @@ module Byebug
         debug_code(program)
 
         check_output_includes "Tracing: (eval):1"
+      end
+    end
+  end
+
+  class ContinueUnconditionallyWithByebugCallsTest < TestCase
+    def program
+      strip_line_numbers <<-RUBY
+         1:  module Byebug
+         2:    byebug
+         3:
+         4:    b = 5
+         5:
+         6:    byebug
+         7:
+         8:    c = b + 5
+         9:
+        10:    d = c + 5
+        11:  end
+      RUBY
+    end
+
+    def test_continues_until_the_end_ignoring_byebug_calls_if_used_with_bang
+      with_mode(:attached) do
+        enter "continue!"
+
+        debug_code(program) { assert_program_finished }
+      end
+    end
+
+    def test_continues_until_the_end_ignoring_byebug_calls_if_used_with_unconditionally
+      with_mode(:attached) do
+        enter "continue unconditionally"
+
+        debug_code(program) { assert_program_finished }
       end
     end
   end

--- a/test/runner_against_program_with_byebug_call_test.rb
+++ b/test/runner_against_program_with_byebug_call_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Byebug
+  #
+  # Tests standalone byebug when debugging a target program
+  #
+  class RunnerAgainstProgramWithByebugCallTest < TestCase
+    def setup
+      super
+
+      example_file.write("require 'byebug'\nbyebug\nsleep 0")
+      example_file.close
+    end
+
+    def test_run_with_a_script_to_debug
+      stdout = run_program(
+        ["ruby", example_path],
+        'puts "Program: #{$PROGRAM_NAME}"'
+      )
+
+      assert_match(/Program: #{example_path}/, stdout)
+    end
+  end
+end


### PR DESCRIPTION
The `continue!` command was not ignoring further `byebug` calls as expected.

### Before

```
$ ruby -r byebug sum.rb 

[1, 9] in /home/deivid/Code/byebug/sum.rb
   1: sum = 0
   2: 
   3: 2.times do |i|
   4:   byebug
=> 5:   sum += i
   6: end
   7: 
   8: byebug
   9: puts "Sum is #{sum}"
(byebug) c!

[1, 9] in /home/deivid/Code/byebug/sum.rb
   1: sum = 0
   2: 
   3: 2.times do |i|
   4:   byebug
=> 5:   sum += i
   6: end
   7: 
   8: byebug
   9: puts "Sum is #{sum}"
(byebug) c!

[1, 9] in /home/deivid/Code/byebug/sum.rb
   1: sum = 0
   2: 
   3: 2.times do |i|
   4:   byebug
   5:   sum += i
   6: end
   7: 
   8: byebug
=> 9: puts "Sum is #{sum}"
(byebug) c!
Sum is 1
```

### After

```
$ RUBYOPT=-Ilib ruby -r byebug sum.rb 

[1, 9] in /home/deivid/Code/byebug/sum.rb
   1: sum = 0
   2: 
   3: 2.times do |i|
   4:   byebug
=> 5:   sum += i
   6: end
   7: 
   8: byebug
   9: puts "Sum is #{sum}"
(byebug) c!
Sum is 1
```