### PR TITLE
Add the byebug line # to make the output clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* [#553](https://github.com/deivid-rodriguez/byebug/pull/553): Shows the line number in the byebug statement so that supporting IDEs can take cursor to the debug point instead of the head of the file ([@senhalil]).
+
 ## [13.0.0] - 2026-01-15
 
 ### Fixed

--- a/lib/byebug/commands/list.rb
+++ b/lib/byebug/commands/list.rb
@@ -113,7 +113,7 @@ module Byebug
     # @param max [Integer] Upper bound
     #
     def display_lines(min, max)
-      puts "\n[#{min}, #{max}] in #{frame.file}"
+      puts "\nStopped at #{frame.file}:#{frame.line}. Showing lines [#{min}, #{max}]:"
 
       puts source_file_formatter.lines(min, max).join
     end

--- a/test/commands/list_test.rb
+++ b/test/commands/list_test.rb
@@ -33,7 +33,7 @@ module Byebug
         enter "list"
         debug_code(program)
 
-        check_output_includes "[12, 14] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:13. Showing lines [12, 14]:"
       end
     end
 
@@ -42,7 +42,7 @@ module Byebug
         enter "set listsize 5.0", "list"
         debug_code(program)
 
-        check_output_doesnt_include "[11, 15] in #{example_path}"
+        check_output_doesnt_include "Stopped at #{example_path}:13. Showing lines [11, 15]:"
       end
     end
 
@@ -51,7 +51,7 @@ module Byebug
         enter "cont 7", "list"
         debug_code(program)
 
-        check_output_includes "[1, 15] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:7. Showing lines [1, 15]:"
       end
     end
 
@@ -60,7 +60,7 @@ module Byebug
         enter "list"
         debug_code(program)
 
-        check_output_includes "[4, 16] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:13. Showing lines [4, 16]:"
       end
     end
 
@@ -69,7 +69,7 @@ module Byebug
         enter "list"
         debug_code(program)
 
-        check_output_includes "[1, 16] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:13. Showing lines [1, 16]:"
       end
     end
 
@@ -78,7 +78,7 @@ module Byebug
         enter "cont 7", "list", "list"
         debug_code(program)
 
-        check_output_includes "[9, 11] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:7. Showing lines [9, 11]:"
       end
     end
 
@@ -87,7 +87,7 @@ module Byebug
         enter "list-"
         debug_code(program)
 
-        check_output_includes "[12, 14] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:13. Showing lines [12, 14]:"
       end
     end
 
@@ -96,7 +96,7 @@ module Byebug
         enter "list-", "list-"
         debug_code(program)
 
-        check_output_includes "[9, 11] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:13. Showing lines [9, 11]:"
       end
     end
 
@@ -105,7 +105,7 @@ module Byebug
         enter "list 14-16", "list -"
         debug_code(program)
 
-        check_output_includes "[11, 13] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:13. Showing lines [11, 13]:"
       end
     end
 
@@ -114,7 +114,7 @@ module Byebug
         enter "list ="
         debug_code(program)
 
-        check_output_includes "[12, 14] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:13. Showing lines [12, 14]:"
       end
     end
 
@@ -122,14 +122,14 @@ module Byebug
       enter "list 6-8"
       debug_code(program)
 
-      check_output_includes "[6, 8] in #{example_path}"
+      check_output_includes "Stopped at #{example_path}:13. Showing lines [6, 8]:"
     end
 
     def test_lists_specific_range_when_requested_in_comma_format
       enter "list 6,8"
       debug_code(program)
 
-      check_output_includes "[6, 8] in #{example_path}"
+      check_output_includes "Stopped at #{example_path}:13. Showing lines [6, 8]:"
     end
 
     def test_lists_nothing_if_unexistent_range_is_specified
@@ -137,7 +137,7 @@ module Byebug
       debug_code(program)
 
       check_error_includes '"List" argument "20" needs to be at most 16'
-      check_output_doesnt_include "[20, 25] in #{example_path}"
+      check_output_doesnt_include "Stopped at #{example_path}:13. Showing lines [20, 25]:"
     end
 
     def test_lists_nothing_if_invalid_range_is_specified
@@ -145,7 +145,7 @@ module Byebug
       debug_code(program)
 
       check_error_includes "Invalid line range"
-      check_output_doesnt_include "[5, 4] in #{example_path}"
+      check_output_doesnt_include "Stopped at #{example_path}:13. Showing lines [5, 4]:"
     end
 
     def test_list_proper_lines_when_range_around_specific_line_with_hyphen
@@ -153,7 +153,7 @@ module Byebug
         enter "list 4-"
         debug_code(program)
 
-        check_output_includes "[3, 5] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:13. Showing lines [3, 5]:"
       end
     end
 
@@ -162,7 +162,7 @@ module Byebug
         enter "list 4,"
         debug_code(program)
 
-        check_output_includes "[3, 5] in #{example_path}"
+        check_output_includes "Stopped at #{example_path}:13. Showing lines [3, 5]:"
       end
     end
 

--- a/test/processors/command_processor_test.rb
+++ b/test/processors/command_processor_test.rb
@@ -202,7 +202,7 @@ module Byebug
     def test_autolists_lists_source_before_stopping
       debug_code(program)
 
-      check_output_includes "[5, 14] in #{example_path}"
+      check_output_includes "Stopped at #{example_path}:11. Showing lines [5, 14]:"
     end
 
     def test_shows_error_when_current_source_location_is_unknown


### PR DESCRIPTION
Adding the exact line number of the byebug statement to the end of the filename on the output makes the statement clickable in IDE's and editors supporting this functionality. Currently clicking the path goes to the top of the file. With the modification, clicking takes the user to the exact byebug line in the document.

For example in vscode it looks like follows:
![vscode_byebug](https://user-images.githubusercontent.com/20163961/55960570-5ba15080-5c6d-11e9-9f08-117a2df5d148.png)
