### PR TITLE
Fix intermittent test hang

### DIFF
--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -62,6 +62,7 @@ module Byebug
       interface.test_block = block
       debug_in_temp_file(program)
       interface.test_block&.call
+      interface.test_block = nil
     end
 
     #


### PR DESCRIPTION
`test_block` was not being properly reset in some cases, and was being leaked to other tests.

See for example https://circleci.com/gh/deivid-rodriguez/byebug/9843?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link.

Tentatively fixes #428.