### PR TITLE
Fix post mortem location after exception inside `load`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* [#562](https://github.com/deivid-rodriguez/byebug/pull/562): post mortem mode landing in the wrong line when coming from an exception inside a `Kernel.load` call.
+
 ### Removed
 
 * Support for MRI 2.3. Byebug no longer installs on this platform.

--- a/ext/byebug/byebug.c
+++ b/ext/byebug/byebug.c
@@ -436,7 +436,7 @@ raise_event(VALUE trace_point, void *data)
 
   raised_exception = rb_tracearg_raised_exception(trace_arg);
 
-  if (post_mortem == Qtrue)
+  if (post_mortem == Qtrue && !rb_ivar_defined(raised_exception, rb_intern("@__bb_context")))
   {
     pm_context = context_dup(dc);
     rb_ivar_set(raised_exception, rb_intern("@__bb_context"), pm_context);

--- a/test/post_mortem_test.rb
+++ b/test/post_mortem_test.rb
@@ -48,7 +48,6 @@ module Byebug
     end
 
     def test_execution_is_stopped_at_the_correct_line_after_exception
-      skip("See issue #165")
       with_setting :post_mortem, true do
         enter "cont"
 


### PR DESCRIPTION
After https://github.com/ruby/ruby/commit/1998039ea4f867583d7e37ce200a88490707c330, our post mortem debugging partially broke, because ruby started emitting two `:raise` events when an exception would happen during a `load` call. In this situation, the second `:raise` event would overwrite the first one, and the context location would be incorrect, leaving the user in an unexpected location.

We fix the issue by watching for the case where we have already saved the context to the raised exception, and avoiding the overwrite.

Fixes #165. 