### PR TITLE
Use a file in our control to test the -r flag

### DIFF
--- a/test/runner_against_valid_program_test.rb
+++ b/test/runner_against_valid_program_test.rb
@@ -82,9 +82,9 @@ module Byebug
 
     def test_run_with_require_flag
       stdout = run_byebug(
-        "-r", "abbrev", example_path,
+        "-r", example_path, example_path,
         input: \
-          'puts "Abbrev loaded? #{$LOADED_FEATURES.last.include?(\'abbrev\')}"'
+          "puts \"Abbrev loaded? \#{$LOADED_FEATURES.last == '#{example_path}'}\""
       )
 
       assert_match(/Abbrev loaded\? true/, stdout)


### PR DESCRIPTION
Since https://github.com/ruby/ruby/commit/559dca509d2a98584b09c7d9a6d74749ce793ad7, `irb` (which we load) loads `rdoc`, which in turn loads `abbrev`.

That means the previous version of this test was broken.

Fix it by using a file under our control, so that external changes to the language don't break our suite.