### PR TITLE
Remove old workaround

### DIFF
--- a/ext/byebug/byebug.c
+++ b/ext/byebug/byebug.c
@@ -305,14 +305,7 @@ call_event(VALUE trace_point, void *data)
 
   CALL_EVENT_SETUP;
 
-  /* nil method_id means we are at top level so there can't be a method
-   * breakpoint here. Just leave then. */
   msym = rb_tracearg_method_id(trace_arg);
-  if (NIL_P(msym))
-  {
-    EVENT_TEARDOWN;
-    return;
-  }
 
   mid = SYM2ID(msym);
   klass = rb_tracearg_defined_class(trace_arg);

--- a/test/commands/next_test.rb
+++ b/test/commands/next_test.rb
@@ -266,4 +266,25 @@ module Byebug
       debug_code(program) { assert_equal 9, frame.line }
     end
   end
+
+  #
+  # Test top-level block events are properly handled
+  #
+  class TopLevelBlockEventsTest < TestCase
+    def program
+      strip_line_numbers <<-RUBY
+        1:  byebug
+        2:
+        3:  1.times {}
+        4:
+        5:  sleep 0
+      RUBY
+    end
+
+    def test_top_level_b_call_event
+      enter "next"
+
+      debug_code(program) { assert_equal 5, frame.line }
+    end
+  end
 end


### PR DESCRIPTION
A while ago, we used to provide the same handler for `:call`, `:b_call`, and `:class` events. At that time, we need to make this exception because `:b_call` events don't include `method_id` at the top level.

Nowadays, this is part of the `:call` handler, while the other events are handled separately. So the tracepoint information always include the `method_id` and we can remove the workaround.