### PR TITLE
Add a setting to omit the exit prompt

### DIFF
--- a/lib/byebug/commands/quit.rb
+++ b/lib/byebug/commands/quit.rb
@@ -31,7 +31,7 @@ module Byebug
     end
 
     def execute
-      return unless @match[1] || confirm(pr("quit.confirmations.really"))
+      return unless @match[1] || !Setting[:prompt_on_exit] || confirm(pr("quit.confirmations.really"))
 
       processor.interface.autosave
       processor.interface.close

--- a/lib/byebug/settings/prompt_on_exit.rb
+++ b/lib/byebug/settings/prompt_on_exit.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../setting"
+
+module Byebug
+  #
+  # Setting to toggle the exit prompt
+  #
+  class PromptOnExitSetting < Setting
+    DEFAULT = true
+
+    def banner
+      "Display exit prompt when quitting"
+    end
+
+    def to_s
+      "Exit prompt enabled? #{value}\n"
+    end
+  end
+end

--- a/test/commands/quit_test.rb
+++ b/test/commands/quit_test.rb
@@ -39,6 +39,17 @@ module Byebug
       end
     end
 
+    def test_quit_quites_immediately_if_exit_prompt_disabled
+      with_setting :prompt_on_exit, false do
+        faking_exit! do
+          enter "q"
+          debug_code(minimal_program)
+
+          check_output_doesnt_include "Really quit? (y/n)"
+        end
+      end
+    end
+
     def test_does_not_quit_if_user_did_not_confirm
       enter "quit", "n"
       debug_code(minimal_program)


### PR DESCRIPTION
With `no_exit_prompt` setting byebug will always quit immediately when `q` is pressed.

Resolves #404 