### PR TITLE
Use prereleases of rubygems and bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,4 +86,4 @@ DEPENDENCIES
   yard (= 0.9.20)
 
 BUNDLED WITH
-   2.0.2
+   2.1.0.pre.3

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -4,8 +4,8 @@ set -eo pipefail
 
 set +x
 
-gem update --system 3.0.6
-gem install bundler --version 2.0.2 --force
+gem update --system 3.1.0.pre.3
+gem install bundler --version 2.1.0.pre.3 --force
 
 bundle install --jobs 3 --retry 3
 


### PR DESCRIPTION
CI is failing on some rubygems code, and the issue seems fixed on the latest prereleases, so upgrading.