### PR TITLE
Fix compile warnings on ruby 2.7.0rc2

### DIFF
--- a/ext/byebug/context.c
+++ b/ext/byebug/context.c
@@ -178,16 +178,29 @@ open_debug_inspector(struct call_with_inspection_data *cwi)
 }
 
 static VALUE
+open_debug_inspector_ensure(VALUE v)
+{
+  return open_debug_inspector((struct call_with_inspection_data *)v);
+}
+
+
+static VALUE
 close_debug_inspector(struct call_with_inspection_data *cwi)
 {
   cwi->dc->backtrace = Qnil;
   return Qnil;
 }
 
+static VALUE
+close_debug_inspector_ensure(VALUE v)
+{
+  return close_debug_inspector((struct call_with_inspection_data *)v);
+}
+
 extern VALUE
 call_with_debug_inspector(struct call_with_inspection_data *data)
 {
-  return rb_ensure(open_debug_inspector, (VALUE)data, close_debug_inspector,
+  return rb_ensure(open_debug_inspector_ensure, (VALUE)data, close_debug_inspector_ensure,
                    (VALUE)data);
 }
 


### PR DESCRIPTION
When compile byebug with ruby 2.7.0rc2 these warnings are shown.
This is caused by
https://git.ruby-lang.org/ruby.git/commit/?id=703783324c16b8b2b50210d1a7d1119902abbb8b
Then wrapping first and third arguments of rb_ensure with wrapper functions.

```
../../../../ext/byebug/context.c:190:20: warning: incompatible pointer types passing 'VALUE (struct call_with_inspection_data *)'
      (aka 'unsigned long (struct call_with_inspection_data *)') to parameter of type 'VALUE (*)(VALUE)'
      (aka 'unsigned long (*)(unsigned long)') [-Wincompatible-pointer-types]
  return rb_ensure(open_debug_inspector, (VALUE)data, close_debug_inspector,
                   ^~~~~~~~~~~~~~~~~~~~
/Users/yuichirokaneko/.rbenv/versions/2.7.0-rc2/include/ruby-2.7.0/ruby/ruby.h:1990:24: note: passing argument to parameter here
VALUE rb_ensure(VALUE(*)(VALUE),VALUE,VALUE(*)(VALUE),VALUE);
                       ^
../../../../ext/byebug/context.c:190:55: warning: incompatible pointer types passing 'VALUE (struct call_with_inspection_data *)'
      (aka 'unsigned long (struct call_with_inspection_data *)') to parameter of type 'VALUE (*)(VALUE)'
      (aka 'unsigned long (*)(unsigned long)') [-Wincompatible-pointer-types]
  return rb_ensure(open_debug_inspector, (VALUE)data, close_debug_inspector,
                                                      ^~~~~~~~~~~~~~~~~~~~~
/Users/yuichirokaneko/.rbenv/versions/2.7.0-rc2/include/ruby-2.7.0/ruby/ruby.h:1990:46: note: passing argument to parameter here
VALUE rb_ensure(VALUE(*)(VALUE),VALUE,VALUE(*)(VALUE),VALUE);
                                             ^
```