### PR TITLE
Fix argc of rb_define_singleton_method for dt_inherited

### DIFF
--- a/ext/byebug/context.c
+++ b/ext/byebug/context.c
@@ -682,5 +682,5 @@ Init_byebug_context(VALUE mByebug)
   rb_define_method(cContext, "tracing=", Context_set_tracing, 1);
 
   cDebugThread = rb_define_class_under(mByebug, "DebugThread", rb_cThread);
-  rb_define_singleton_method(cDebugThread, "inherited", dt_inherited, 1);
+  rb_define_singleton_method(cDebugThread, "inherited", dt_inherited, 0);
 }


### PR DESCRIPTION
argc of rb_define_singleton_method means the number of parameters
excluding klass itself. On the other hand dt_inherited expects
only klass as arguments. Then 0 is appropriate in this case.