### PR TITLE
Fix test_thread_list_shows_all_available_threads on ruby 2.7.0rc2

### DIFF
--- a/test/commands/thread_test.rb
+++ b/test/commands/thread_test.rb
@@ -82,9 +82,9 @@ module Byebug
       debug_code(program)
 
       check_output_includes(
-        /(\+)?\d+ #<Thread:0x\h+(@.+:\d+)? (sleep|sleep_forever|run)>/,
-        /(\+)?\d+ #<Thread:0x\h+(@.+:\d+)? (sleep|sleep_forever|run)>/,
-        /(\+)?\d+ #<Thread:0x\h+(@.+:\d+)? (sleep|sleep_forever|run)>/
+        /(\+)?\d+ #<Thread:0x\h+(.+:\d+)? (sleep|sleep_forever|run)>/,
+        /(\+)?\d+ #<Thread:0x\h+(.+:\d+)? (sleep|sleep_forever|run)>/,
+        /(\+)?\d+ #<Thread:0x\h+(.+:\d+)? (sleep|sleep_forever|run)>/
       )
     end
 


### PR DESCRIPTION
Format of `Thread#to_s` was changed by
https://git.ruby-lang.org/ruby.git/commit/?id=8a80bfcfd4d510a20a62e21d8d2f4119cb823d4f
This commit relaxes regexp of the test case.

```
$ RBENV_VERSION=2.6.5 ruby -e 'p Thread.new { while true do sleep 1 end}'
#<Thread:0x00007fb1818fc9f8@-e:1 run>

$ RBENV_VERSION=2.7.0-rc2 ruby -e 'p Thread.new { while true do sleep 1 end}'
#<Thread:0x00007f7f29889640 -e:1 run>
```