### PR TITLE
Update json gem to fix tests on ruby 2.7.0rc2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     jaro_winkler (1.5.4)
-    json (2.2.0)
+    json (2.3.0)
     kramdown (2.1.0)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)


### PR DESCRIPTION
These test cases fails if we run test on ruby 2.7.0rc2.

* Byebug::MinitestRunnerTest#test_runs
* Byebug::MinitestRunnerTest#test_with_seed_option
* Byebug::MinitestRunnerTest#test_combinations
* Byebug::MinitestRunnerTest#test_per_test
* Byebug::MinitestRunnerTest#test_per_test_class

The cause is that json-2.2.0 shows warnings about
keyword parameters like

```
/Users/yuichirokaneko/ruby/byebug/vendor/bundle/ruby/2.7.0/gems/json-2.2.0/lib/json/common.rb:156: warning: The last argument is used as keyword parameters
```

Then update json gem to fix these test cases.