### PR TITLE
Improve test suite timeouts

### DIFF
--- a/test/minitest_runner.rb
+++ b/test/minitest_runner.rb
@@ -27,9 +27,14 @@ module Byebug
 
     private
 
+    def max_running_time
+      300
+    end
+
     def run_with_timeout(flags)
-      Timeout.timeout(300) { Minitest.run(flags + $ARGV) }
+      Timeout.timeout(max_running_time) { Minitest.run(flags + $ARGV) }
     rescue Timeout::Error
+      warn "Test suite timed out after #{max_running_time} seconds"
       false
     end
 

--- a/test/minitest_runner.rb
+++ b/test/minitest_runner.rb
@@ -28,7 +28,7 @@ module Byebug
     private
 
     def run_with_timeout(flags)
-      Timeout.timeout(180) { Minitest.run(flags + $ARGV) }
+      Timeout.timeout(300) { Minitest.run(flags + $ARGV) }
     rescue Timeout::Error
       false
     end


### PR DESCRIPTION
Make it clear to the user when they happen, and increase the value in seconds a bit.