### PR TITLE
Support TESTOPTS in our minitest runner

### DIFF
--- a/test/minitest_runner.rb
+++ b/test/minitest_runner.rb
@@ -20,7 +20,11 @@ module Byebug
     def run
       test_suites.each { |f| require File.expand_path(f) }
 
-      flags = ["--name=/#{filtered_methods.join('|')}/"]
+      flags = if ENV["TESTOPTS"]
+                ENV["TESTOPTS"].split(" ")
+              else
+                ["--name=/#{filtered_methods.join('|')}/"]
+              end
 
       run_with_timeout(flags)
     end


### PR DESCRIPTION
If using our minitest runner, it's more handy to specify options directly (`bin/minitest --verbose`). But if used through the rake task, supporting `TESTOPTS` is useful.

This PR gives priority to `TESTOPTS` if given.