### PR TITLE
Go back to a full `require` for requiring the extension

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -1,0 +1,34 @@
+---
+
+name: fedora
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    container: fedora:31
+
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install OS dependencies
+        run: dnf install -y ruby ruby-devel make gcc redhat-rpm-config
+
+      - name: Install bundler
+        run: gem install bundler:2.1.4
+
+      - name: Install development dependencies
+        run: bundle install
+
+      - name: Install byebug
+        run: bin/rake install
+
+      - name: Run byebug
+        run: byebug -h

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* [#635](https://github.com/deivid-rodriguez/byebug/pull/635): usage on Fedora 31 or any other `byebug` installation performed by a `rubygems` copy customized by setting `Gem.install_extension_in_lib` to false.
+
 ## [11.1.0] - 2020-01-20
 
 ### Added

--- a/lib/byebug/core.rb
+++ b/lib/byebug/core.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "helpers/reflection"
-require_relative "byebug"
+require "byebug/byebug"
 require_relative "context"
 require_relative "breakpoint"
 require_relative "interface"


### PR DESCRIPTION
This fixes byebug usage in Fedora. Fedora's rubygems uses a switch to prevent compiled extensions from being installed into each gem's lib/ directory (`Gem.install_extension_in_lib = false`). So byebug doesn't properly work there.

Going back to a require fixes the issue.
