### PR TITLE
Remove unneeded selfs in Byebug::History and fix typos

### DIFF
--- a/lib/byebug/commands/info.rb
+++ b/lib/byebug/commands/info.rb
@@ -31,7 +31,7 @@ module Byebug
     end
 
     def self.short_description
-      "Shows several informations about the program being debugged"
+      "Shows short description and information about the program being debugged"
     end
   end
 end

--- a/lib/byebug/commands/step.rb
+++ b/lib/byebug/commands/step.rb
@@ -7,7 +7,7 @@ module Byebug
   #
   # Implements the step functionality.
   #
-  # Allows the user the continue execution until the next instruction, possibily
+  # Allows the user the continue execution until the next instruction, possibly
   # in a different frame. Use step to step into method calls or blocks.
   #
   class StepCommand < Command

--- a/lib/byebug/commands/tracevar.rb
+++ b/lib/byebug/commands/tracevar.rb
@@ -4,7 +4,7 @@ require_relative "../command"
 
 module Byebug
   #
-  # Show (and possibily stop) at every line that changes a global variable.
+  # Show (and possibly stop) at every line that changes a global variable.
   #
   class TracevarCommand < Command
     def self.regexp

--- a/lib/byebug/helpers/reflection.rb
+++ b/lib/byebug/helpers/reflection.rb
@@ -3,7 +3,7 @@
 module Byebug
   module Helpers
     #
-    # Reflection utilitie
+    # Reflection utility
     #
     module ReflectionHelper
       #

--- a/lib/byebug/history.rb
+++ b/lib/byebug/history.rb
@@ -17,10 +17,10 @@ module Byebug
   # Handles byebug's history of commands.
   #
   class History
-    attr_accessor :size
+    attr_reader :size
 
     def initialize
-      self.size = 0
+      @size = 0
     end
 
     #
@@ -65,7 +65,7 @@ module Byebug
     def push(cmd)
       return if ignore?(cmd)
 
-      self.size += 1
+      @size += 1
       Readline::HISTORY.push(cmd)
     end
 
@@ -73,7 +73,7 @@ module Byebug
     # Removes a command from Readline's history.
     #
     def pop
-      self.size -= 1
+      @size -= 1
       Readline::HISTORY.pop
     end
 
@@ -103,7 +103,7 @@ module Byebug
     # Never more than Setting[:histsize].
     #
     def default_max_size
-      [Setting[:histsize], self.size].min
+      [Setting[:histsize], size].min
     end
 
     #
@@ -112,7 +112,7 @@ module Byebug
     # The only bound here is not showing more items than available.
     #
     def specific_max_size(number)
-      [self.size, number].min
+      [size, number].min
     end
 
     #

--- a/test/commands/finish_test.rb
+++ b/test/commands/finish_test.rb
@@ -65,7 +65,7 @@ module Byebug
       debug_code(program) { assert_equal 12, frame.line }
     end
 
-    def test_finish_behaves_consistenly_even_if_current_frame_has_been_changed
+    def test_finish_behaves_consistently_even_if_current_frame_has_been_changed
       enter "break 21", "cont", "up", "finish"
 
       debug_code(program) { assert_equal 12, frame.line }

--- a/test/commands/help_test.rb
+++ b/test/commands/help_test.rb
@@ -29,7 +29,7 @@ module Byebug
       frame: "Moves to a frame in the call stack",
       help: "Helps you using byebug",
       history: "Shows byebug's history of commands",
-      info: "Shows several informations about the program being debugged",
+      info: "Shows short description and information about the program being debugged",
       interrupt: "Interrupts the program",
       irb: "Starts an IRB session",
       kill: "Sends a signal to the current process",

--- a/test/commands/history_test.rb
+++ b/test/commands/history_test.rb
@@ -33,7 +33,7 @@ unless ENV["LIBEDIT"]
         check_output_includes(/\d+  show$/, /\d+  history 3$/)
       end
 
-      def test_history_n_displays_lastest_n_records_from_readline_history
+      def test_history_n_displays_latest_n_records_from_readline_history
         enter "show width", "show autolist", "history 2"
         debug_code(program)
 

--- a/test/commands/info_test.rb
+++ b/test/commands/info_test.rb
@@ -131,7 +131,7 @@ module Byebug
       debug_code(program)
 
       check_output_includes \
-        "Shows several informations about the program being debugged"
+        "Shows short description and information about the program being debugged"
     end
   end
 

--- a/test/commands/quit_test.rb
+++ b/test/commands/quit_test.rb
@@ -21,7 +21,7 @@ module Byebug
       end
     end
 
-    def test_quit_quits_inmediately_if_used_with_bang
+    def test_quit_quits_immediately_if_used_with_bang
       faking_exit! do
         enter "quit!"
         debug_code(minimal_program)
@@ -30,7 +30,7 @@ module Byebug
       end
     end
 
-    def test_quit_quits_inmediately_if_used_with_unconditionally
+    def test_quit_quits_immediately_if_used_with_unconditionally
       faking_exit! do
         enter "quit unconditionally"
         debug_code(minimal_program)

--- a/test/commands/set_test.rb
+++ b/test/commands/set_test.rb
@@ -55,7 +55,7 @@ module Byebug
       end
     end
 
-    def test_set_does_not_enable_a_setting_using_shorcut_when_ambiguous
+    def test_set_does_not_enable_a_setting_using_shortcut_when_ambiguous
       with_setting :autolist, false do
         enter "set auto"
         debug_code(program)
@@ -64,7 +64,7 @@ module Byebug
       end
     end
 
-    def test_set_enables_a_setting_using_shorcut_when_not_ambiguous
+    def test_set_enables_a_setting_using_shortcut_when_not_ambiguous
       with_setting :autolist, false do
         enter "set autol"
         debug_code(program)
@@ -73,7 +73,7 @@ module Byebug
       end
     end
 
-    def test_set_does_not_disable_a_setting_using_shorcut_when_ambiguous
+    def test_set_does_not_disable_a_setting_using_shortcut_when_ambiguous
       with_setting :autolist, true do
         enter "set noauto"
         debug_code(program)

--- a/test/support/temporary.rb
+++ b/test/support/temporary.rb
@@ -98,7 +98,7 @@ module Byebug
     # Runs the block with a temporary value for an ENV variable
     #
     # @param key [String] Name for the key in the ENV hash
-    # @param vlaue [String] Value of the key in the ENV hash
+    # @param value [String] Value of the key in the ENV hash
     #
     def with_env(key, value)
       old_value = ENV[key]


### PR DESCRIPTION
Minor improvements to consistency of instance variables in `Byebug::History` to better match Ruby conventions.

I also searched for typos using [cspell](https://www.npmjs.com/package/cspell). I manually fixed the obvious typos that were reported (and ignored tons of false positive matches).