### PR TITLE
runner_against_program_with_byebug_call_test: call the correct ruby

### DIFF
--- a/test/runner_against_program_with_byebug_call_test.rb
+++ b/test/runner_against_program_with_byebug_call_test.rb
@@ -16,7 +16,7 @@ module Byebug
 
     def test_run_with_a_script_to_debug
       stdout = run_program(
-        ["ruby", example_path],
+        [RbConfig.ruby, example_path],
         'puts "Program: #{$PROGRAM_NAME}"'
       )
 


### PR DESCRIPTION
On Debian, while we are transitioning between Ruby versions, we have
both the old ruby (e.g. ruby2.5 and ruby2.7) and the new coinstalled,
and we want to test stuff against both of them.