### PR TITLE
test: drop usage of require_relative to code in lib

### DIFF
--- a/test/printers/plain_test.rb
+++ b/test/printers/plain_test.rb
@@ -2,7 +2,7 @@
 
 require_relative "../test_helper"
 require "minitest/mock"
-require_relative "../../lib/byebug/helpers/string"
+require "byebug/helpers/string"
 
 module Byebug
   #

--- a/test/rc_test.rb
+++ b/test/rc_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
-require_relative "../lib/byebug/runner"
+require "byebug/runner"
 
 module Byebug
   class RcTest < TestCase

--- a/test/runner_against_valid_program_test.rb
+++ b/test/runner_against_valid_program_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
-require_relative "../lib/byebug/version"
+require "byebug/version"
 
 module Byebug
   #

--- a/test/runner_without_target_program_test.rb
+++ b/test/runner_without_target_program_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
-require_relative "../lib/byebug/version"
+require "byebug/version"
 
 module Byebug
   #

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require "minitest"
-require_relative "../../lib/byebug"
-require_relative "../../lib/byebug/core"
-require_relative "../../lib/byebug/interfaces/test_interface"
+require "byebug"
+require "byebug/core"
+require "byebug/interfaces/test_interface"
 require_relative "utils"
 
 module Byebug


### PR DESCRIPTION
In Debian and in other QA efforts, one might want to run the test suite
against the code that is installed on the system (as opposed to the one
in the source tree). Using require_relative like this prevents that from
working.