### PR TITLE
Fix crash on TAB under ruby 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* [#657](https://github.com/deivid-rodriguez/byebug/pull/657): crash when hitting \<TAB\> due to IRB completion mechanism included in the default ruby 2.7 version of the `irb` gem ([@terceiro]).
+
 ## [11.1.1] - 2020-01-24
 
 ### Fixed
@@ -911,6 +915,7 @@
 [@sethk]: https://github.com/sethk
 [@shuky19]: https://github.com/shuky19
 [@tacnoman]: https://github.com/tacnoman
+[@terceiro]: https://github.com/terceiro
 [@tzmfreedom]: https://github.com/tzmfreedom
 [@wallace]: https://github.com/wallace
 [@windwiny]: https://github.com/windwiny

--- a/test/runner_against_valid_program_test.rb
+++ b/test/runner_against_valid_program_test.rb
@@ -118,6 +118,15 @@ module Byebug
       assert_match(/Debug flag is true/, stdout)
     end
 
+    def test_run_and_press_tab_doesnt_make_byebug_crash
+      stdout = run_byebug(
+        example_path,
+        input: "\tputs 'Reached here'"
+      )
+
+      assert_match(/Reached here/, stdout)
+    end
+
     def test_run_stops_at_the_first_line_by_default
       stdout = run_byebug(example_path)
 


### PR DESCRIPTION
When IRB from ruby 2.7 is loaded, it installs a Readline completion proc
that assumes IRB is running (and crashes otherwise). Workaround this by
clearing the Readline completion when using it directly.

Fixes #654