### PR TITLE
Move head build to daily

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -34,3 +34,24 @@ jobs:
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+        continue-on-error: true
+
+  test_head_images:
+    container: deividrodriguez/byebug:head-${{ matrix.line_editor }}-${{ matrix.compiler }}
+
+    needs: build_head_images
+
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        line_editor: [libedit, readline]
+        compiler: [clang, gcc]
+
+    steps:
+      - name: Run CI checks
+        run: |
+          bin/setup.sh
+          bin/rake
+
+    timeout-minutes: 15

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [2.4.9, 2.5.7, 2.6.5, 2.7.0, head]
+        version: [2.4.9, 2.5.7, 2.6.5, 2.7.0]
         line_editor: [libedit, readline]
         compiler: [clang, gcc]
 


### PR DESCRIPTION
We want to find out about changes in ruby that break our test, but don't want those changes to make status checks fail for every PR.

So run head build on a daily basis. 