### PR TITLE
Avoid simplecov on new rubies

### DIFF
--- a/test/support/simplecov.rb
+++ b/test/support/simplecov.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "simplecov" if ENV["NOCOV"].nil? && Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6.a")

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -253,11 +253,11 @@ module Byebug
         location.label.start_with?("test_")
       end
 
-      byebug_dir = File.expand_path("../../lib", __dir__)
+      lib_dir = File.expand_path("../../lib", __dir__)
 
       base = {
         "MINITEST_TEST" => "#{self.class}##{minitest_test.label}",
-        "RUBYOPT" => "-I #{byebug_dir}"
+        "RUBYOPT" => "-I #{lib_dir}"
       }
 
       base["RUBYOPT"] += " -r simplecov" if simplecov

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -260,7 +260,10 @@ module Byebug
         "RUBYOPT" => "-I #{lib_dir}"
       }
 
-      base["RUBYOPT"] += " -r simplecov" if simplecov
+      if simplecov
+        test_dir = File.expand_path("..", __dir__)
+        base["RUBYOPT"] += " -r #{test_dir}/support/simplecov.rb"
+      end
 
       base
     end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -253,7 +253,7 @@ module Byebug
         location.label.start_with?("test_")
       end
 
-      byebug_dir = File.absolute_path(File.join("..", "..", "lib"), __dir__)
+      byebug_dir = File.expand_path("../../lib", __dir__)
 
       base = {
         "MINITEST_TEST" => "#{self.class}##{minitest_test.label}",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "simplecov" if ENV["NOCOV"].nil? && Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6.a")
+require "support/simplecov"
 require "support/test_case"
 
 Byebug::TestCase.before_suite


### PR DESCRIPTION
I disabled it in https://github.com/deivid-rodriguez/byebug/pull/659, but it was still getting activated in some places.