### PR TITLE
Break in current line if `break` has no arguments

### DIFF
--- a/lib/byebug/commands/break.rb
+++ b/lib/byebug/commands/break.rb
@@ -27,7 +27,8 @@ module Byebug
         b[reak] [<module>::...]<class>(.|#)<method> [if <expr>]
 
         They can be specified by line or method and an expression can be added
-        for conditionally enabled breakpoints.
+        for conditionally enabled breakpoints. Without arguments create a
+        a breakpoint in the current line.
 
         #{short_description}
       DESCRIPTION
@@ -38,9 +39,9 @@ module Byebug
     end
 
     def execute
-      return puts(help) unless @match[1]
+      b = line_breakpoint(frame.line.to_s) unless @match[1]
 
-      b = line_breakpoint(@match[1]) || method_breakpoint(@match[1])
+      b ||= line_breakpoint(@match[1]) || method_breakpoint(@match[1])
       return errmsg(pr("break.errors.location")) unless b
 
       return puts(pr("break.created", id: b.id, file: b.source, line: b.pos)) if syntax_valid?(@match[2])

--- a/lib/byebug/commands/where.rb
+++ b/lib/byebug/commands/where.rb
@@ -14,12 +14,12 @@ module Byebug
     self.allow_in_post_mortem = true
 
     def self.regexp
-      /^\s* (?:w(?:here)?|bt|backtrace) \s*$/x
+      /^\s* (?:w(?:here)?|bt|backtrace) (?:\s+(\S+))? \s*$/x
     end
 
     def self.description
       <<-DESCRIPTION
-        w[here]|bt|backtrace
+        w[here]|bt|backtrace[ maximum-frame]
 
         #{short_description}
 
@@ -29,6 +29,10 @@ module Byebug
         The position of the current frame is marked with -->. C-frames hang
         from their most immediate Ruby frame to indicate that they are not
         navigable.
+
+        Without an argument, the command prints all the frames. With an argument
+        the command prints the largest between the argument or the maximum stack
+        frame.
       DESCRIPTION
     end
 
@@ -43,7 +47,14 @@ module Byebug
     private
 
     def print_backtrace
-      bt = prc("frame.line", (0...context.stack_size)) do |_, index|
+      max_frame =
+        if @match[1] && @match[1].to_i < context.stack_size
+          @match[1].to_i
+        else
+          context.stack_size
+        end
+
+      bt = prc("frame.line", (0...max_frame)) do |_, index|
         Frame.new(context, index).to_hash
       end
 

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -221,7 +221,7 @@ module Byebug
     end
 
     def test_setting_breakpoint_using_shortcut_properly_adds_the_breakpoint
-      enter "break 7"
+      enter "b 7"
 
       debug_code(program) { assert_equal 1, Byebug.breakpoints.size }
     end

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -336,12 +336,12 @@ module Byebug
       check_error_includes 'Incorrect expression "y -=) 1"; breakpoint disabled'
     end
 
-    def test_shows_info_about_setting_breakpoints_when_using_just_break
-      enter "break", "cont"
-      debug_code(program)
+    #def test_shows_info_about_setting_breakpoints_when_using_just_break
+    #  enter "break", "cont"
+    #  debug_code(program)
 
-      check_output_includes(/b\[reak\] \[<file>:\]<line> \[if <expr>\]/)
-    end
+    #  check_output_includes(/b\[reak\] \[<file>:\]<line> \[if <expr>\]/)
+    #end
 
     def test_setting_breakpoint_uses_new_source
       enter -> { cmd_after_replace(example_path, 7, "", "break 7") }
@@ -477,6 +477,49 @@ module Byebug
       debug_code(program)
 
       check_output_doesnt_include "Return value is: nil"
+    end
+  end
+
+  #
+  # Tests creating a breakpoint in the current line if no argument is passed
+  #
+  class BreakWithoutArguments < TestCase
+    def program
+      strip_line_numbers <<-RUBY
+         1:  module Byebug
+         2:    #
+         3:    # Toy class to test breakpoints
+         4:    #
+         5:    class #{example_class}
+         6:      def self.a
+         7:        y = 1
+         8:        z = 2
+         9:        y + z
+        10:      end
+        11:    end
+        12:
+        13:    byebug
+        14:
+        15:    #{example_class}.a
+        16:  end
+      RUBY
+    end
+
+    def test_setting_breakpoint_sets_correct_fields
+      enter "break"
+
+      debug_code(program) do
+        b = Breakpoint.first
+        exp = [b.pos, b.source, b.expr, b.hit_count, b.hit_value, b.enabled?]
+        act = [15, example_path, nil, 0, 0, true]
+        assert_equal act, exp
+      end
+    end
+
+    def test_setting_breakpoint_using_shortcut_properly_adds_the_breakpoint
+      enter "b"
+
+      debug_code(program) { assert_equal 1, Byebug.breakpoints.size }
     end
   end
 end

--- a/test/commands/where_test.rb
+++ b/test/commands/where_test.rb
@@ -110,6 +110,35 @@ module Byebug
 
       check_output_includes(*expected_output)
     end
+
+    def test_where_with_argument_less_than_largest_frame
+      enter "where 3"
+      debug_code(program)
+
+      expected_output = prepare_for_regexp <<-TXT
+        --> #0  #{example_full_class}.to_int(str#String) at #{example_path}:16
+            #1  #{example_full_class}.encode(str#String) at #{example_path}:11
+            #2  #{example_full_class}.initialize(l#String) at #{example_path}:7
+      TXT
+
+      check_output_includes(*expected_output)
+    end
+
+    def test_where_with_argument_larger_than_largest_frame
+      enter "where 20"
+      debug_code(program)
+
+      expected_output = prepare_for_regexp <<-TXT
+        --> #0  #{example_full_class}.to_int(str#String) at #{example_path}:16
+            #1  #{example_full_class}.encode(str#String) at #{example_path}:11
+            #2  #{example_full_class}.initialize(l#String) at #{example_path}:7
+            ͱ-- #3  Class.new(*args) at #{example_path}:20
+            #4  <module:Byebug> at #{example_path}:20
+            #5  <top (required)> at #{example_path}:1
+      TXT
+
+      check_output_includes(*expected_output)
+    end
   end
 
   #


### PR DESCRIPTION
Set a breakpoint at the next instruction to be executed in the selected stack frame. Like GDB.