### PR TITLE
Pass argument to `where` to print the nth first frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * [#744](https://github.com/deivid-rodriguez/byebug/pull/744): Another punctuation tweak in `enable breakpoints` help message.
 * [#736](https://github.com/deivid-rodriguez/byebug/pull/736): Skip warning about `$SAFE` global variable on ruby 2.7 when listing global variables.
 
+### Added
+
+* [#688](https://github.com/deivid-rodriguez/byebug/pull/688): `where` command now receives an optional numeric argument `<n>` to print the nth first frames.
+
 ### Removed
 
 * Support for MRI 2.4. Byebug no longer installs on this platform.

--- a/lib/byebug/commands/where.rb
+++ b/lib/byebug/commands/where.rb
@@ -14,12 +14,12 @@ module Byebug
     self.allow_in_post_mortem = true
 
     def self.regexp
-      /^\s* (?:w(?:here)?|bt|backtrace) \s*$/x
+      /^\s* (?:w(?:here)?|bt|backtrace) (?:\s+(\S+))? \s*$/x
     end
 
     def self.description
       <<-DESCRIPTION
-        w[here]|bt|backtrace
+        w[here]|bt|backtrace[ maximum-frame]
 
         #{short_description}
 
@@ -29,6 +29,10 @@ module Byebug
         The position of the current frame is marked with -->. C-frames hang
         from their most immediate Ruby frame to indicate that they are not
         navigable.
+
+        Without an argument, the command prints all the frames. With an argument,
+        the command prints the nth first frames, where n is the largest between
+        the argument or the maximum stack frame.
       DESCRIPTION
     end
 
@@ -43,7 +47,14 @@ module Byebug
     private
 
     def print_backtrace
-      bt = prc("frame.line", (0...context.stack_size)) do |_, index|
+      max_frame =
+        if @match[1] && @match[1].to_i <= context.stack_size
+          @match[1].to_i
+        else
+          context.stack_size
+        end
+
+      bt = prc("frame.line", (0...max_frame)) do |_, index|
         Frame.new(context, index).to_hash
       end
 

--- a/test/commands/where_test.rb
+++ b/test/commands/where_test.rb
@@ -110,6 +110,35 @@ module Byebug
 
       check_output_includes(*expected_output)
     end
+
+    def test_where_with_argument_less_than_largest_frame
+      enter "where 3"
+      debug_code(program)
+
+      expected_output = prepare_for_regexp <<-TXT
+        --> #0  #{example_full_class}.to_int(str#String) at #{example_path}:16
+            #1  #{example_full_class}.encode(str#String) at #{example_path}:11
+            #2  #{example_full_class}.initialize(l#String) at #{example_path}:7
+      TXT
+
+      check_output_includes(*expected_output)
+    end
+
+    def test_where_with_argument_greater_than_largest_frame
+      enter "where 20"
+      debug_code(program)
+
+      expected_output = prepare_for_regexp <<-TXT
+        --> #0  #{example_full_class}.to_int(str#String) at #{example_path}:16
+            #1  #{example_full_class}.encode(str#String) at #{example_path}:11
+            #2  #{example_full_class}.initialize(l#String) at #{example_path}:7
+            ͱ-- #3  Class.new(*args) at #{example_path}:20
+            #4  <module:Byebug> at #{example_path}:20
+            #5  <top (required)> at #{example_path}:1
+      TXT
+
+      check_output_includes(*expected_output)
+    end
   end
 
   #


### PR DESCRIPTION
When the frame stack is too deep it's useful pass an argument to `where` to print the nth most recent frames. This pull request replaces  my previous one #681 which had a typo.