### PR TITLE
Break at current line when `break` has no arguments

### DIFF
--- a/lib/byebug/commands/break.rb
+++ b/lib/byebug/commands/break.rb
@@ -23,11 +23,12 @@ module Byebug
 
     def self.description
       <<-DESCRIPTION
-        b[reak] [<file>:]<line> [if <expr>]
+        b[reak] [[<file>:]<line> [if <expr>]]
         b[reak] [<module>::...]<class>(.|#)<method> [if <expr>]
 
         They can be specified by line or method and an expression can be added
-        for conditionally enabled breakpoints.
+        for conditionally enabled breakpoints. Without arguments create a
+        a breakpoint in the current line.
 
         #{short_description}
       DESCRIPTION
@@ -38,9 +39,9 @@ module Byebug
     end
 
     def execute
-      return puts(help) unless @match[1]
+      b = line_breakpoint(frame.line.to_s) unless @match[1]
 
-      b = line_breakpoint(@match[1]) || method_breakpoint(@match[1])
+      b ||= line_breakpoint(@match[1]) || method_breakpoint(@match[1])
       return errmsg(pr("break.errors.location")) unless b
 
       return puts(pr("break.created", id: b.id, file: b.source, line: b.pos)) if syntax_valid?(@match[2])

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -221,7 +221,7 @@ module Byebug
     end
 
     def test_setting_breakpoint_using_shortcut_properly_adds_the_breakpoint
-      enter "break 7"
+      enter "b 7"
 
       debug_code(program) { assert_equal 1, Byebug.breakpoints.size }
     end


### PR DESCRIPTION
Makes it easier to create breakpoints with just `break` or `b`, like in GDB.