### PR TITLE
Break at current line when `break` has no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+* [#690](https://github.com/deivid-rodriguez/byebug/pull/690): `break` without any arguments now sets a breakpoint on the current line, just like `gdb`.
+
 ### Fixed
 
 * [#741](https://github.com/deivid-rodriguez/byebug/pull/741): Small consistency issues in help messages.

--- a/lib/byebug/commands/break.rb
+++ b/lib/byebug/commands/break.rb
@@ -23,13 +23,15 @@ module Byebug
 
     def self.description
       <<-DESCRIPTION
-        b[reak] [<file>:]<line> [if <expr>]
+        b[reak] [[<file>:]<line> [if <expr>]]
         b[reak] [<module>::...]<class>(.|#)<method> [if <expr>]
 
         #{short_description}
 
         They can be specified by line or method and an expression can be added
         for conditionally enabled breakpoints.
+        for conditionally enabled breakpoints. Without arguments create a
+        a breakpoint in the current line.
       DESCRIPTION
     end
 
@@ -38,9 +40,9 @@ module Byebug
     end
 
     def execute
-      return puts(help) unless @match[1]
+      b = line_breakpoint(frame.line.to_s) unless @match[1]
 
-      b = line_breakpoint(@match[1]) || method_breakpoint(@match[1])
+      b ||= line_breakpoint(@match[1]) || method_breakpoint(@match[1])
       return errmsg(pr("break.errors.location")) unless b
 
       return puts(pr("break.created", id: b.id, file: b.source, line: b.pos)) if syntax_valid?(@match[2])

--- a/lib/byebug/commands/break.rb
+++ b/lib/byebug/commands/break.rb
@@ -26,10 +26,10 @@ module Byebug
         b[reak] [<file>:]<line> [if <expr>]
         b[reak] [<module>::...]<class>(.|#)<method> [if <expr>]
 
+        #{short_description}
+
         They can be specified by line or method and an expression can be added
         for conditionally enabled breakpoints.
-
-        #{short_description}
       DESCRIPTION
     end
 

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -312,13 +312,6 @@ module Byebug
       check_error_includes 'Incorrect expression "y -=) 1"; breakpoint disabled'
     end
 
-    def test_shows_info_about_setting_breakpoints_when_using_just_break
-      enter "break", "cont"
-      debug_code(program)
-
-      check_output_includes(/b\[reak\] \[<file>:\]<line> \[if <expr>\]/)
-    end
-
     def test_setting_breakpoint_uses_new_source
       enter -> { cmd_after_replace(example_path, 7, "", "break 7") }
 
@@ -453,6 +446,49 @@ module Byebug
       debug_code(program)
 
       check_output_doesnt_include "Return value is: nil"
+    end
+  end
+
+  #
+  # Tests creating a breakpoint in the current line if no argument is passed
+  #
+  class BreakWithoutArguments < TestCase
+    def program
+      strip_line_numbers <<-RUBY
+         1:  module Byebug
+         2:    #
+         3:    # Toy class to test breakpoints
+         4:    #
+         5:    class #{example_class}
+         6:      def self.a
+         7:        y = 1
+         8:        z = 2
+         9:        y + z
+        10:      end
+        11:    end
+        12:
+        13:    byebug
+        14:
+        15:    #{example_class}.a
+        16:  end
+      RUBY
+    end
+
+    def test_setting_breakpoint_sets_correct_fields
+      enter "break"
+
+      debug_code(program) do
+        b = Breakpoint.first
+        exp = [b.pos, b.source, b.expr, b.hit_count, b.hit_value, b.enabled?]
+        act = [15, example_path, nil, 0, 0, true]
+        assert_equal act, exp
+      end
+    end
+
+    def test_setting_breakpoint_using_shortcut_properly_adds_the_breakpoint
+      enter "b"
+
+      debug_code(program) { assert_equal 1, Byebug.breakpoints.size }
     end
   end
 end

--- a/test/commands/help_test.rb
+++ b/test/commands/help_test.rb
@@ -86,10 +86,14 @@ module Byebug
       debug_code(minimal_program)
 
       expected_output = split_lines <<-TXT
-        b[reak] [<file>:]<line> [if <expr>]
+        b[reak] [[<file>:]<line> [if <expr>]]
         b[reak] [<module>::...]<class>(.|#)<method> [if <expr>]
 
         Sets breakpoints in the source code
+
+        They can be specified by line or method and an expression can be added
+        for conditionally enabled breakpoints. Without arguments create a
+        a breakpoint in the current line.
       TXT
 
       check_output_includes(*expected_output)


### PR DESCRIPTION
Makes it easier to create breakpoints with just `break` or `b`, like in GDB.