### PR TITLE
Set default history file to ~/.byebug_history

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_PATH: ".bundle"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [2.4.9, 2.5.7, 2.6.5, head]
+        version: [2.4.9, 2.5.7, 2.6.5, 2.7.0, head]
 
     steps:
       - uses: actions/checkout@v2
@@ -33,8 +33,7 @@ jobs:
         run: |
           git clone -q --depth=5  --no-tags --branch=byebug https://github.com/deivid-rodriguez/rb-readline.git C:\rb-readline
           $n_dir = $(ruby -e "print RbConfig::CONFIG['sitelibdir']")
-          Copy-Item -Path C:\rb-readline\lib\readline.rb -Destination $n_dir\readline.rb
-          Copy-Item -Path C:\rb-readline\lib\rbreadline.rb -Destination $n_dir\rbreadline.rb
+          Copy-Item -Path C:\rb-readline\lib\* -Destination $n_dir -Recurse
 
       - name: Setup dependencies
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ coverage
 
 lib/byebug/byebug.so
 lib/byebug/byebug.bundle
+
+test

--- a/.tags
+++ b/.tags
@@ -1,0 +1,2317 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+0.0.1 - 2013-03-18	CHANGELOG.md	/^## 0.0.1 - 2013-03-18$/;"	h
+A manager doing his thing	GUIDE.md	/^# A manager doing his thing$/;"	h
+Actual behavior	.github/ISSUE_TEMPLATE.md	/^## Actual behavior$/;"	h
+Add_catchpoint	ext/byebug/byebug.c	/^Add_catchpoint(VALUE self, VALUE value)$/;"	f	file:	signature:(VALUE self, VALUE value)
+Added	CHANGELOG.md	/^### Added$/;"	h
+AllCommand	lib/byebug/commands/var/all.rb	/^    class AllCommand < Command$/;"	c	class:Byebug.VarCommand
+An employee doing his thing	GUIDE.md	/^# An employee doing his thing$/;"	h
+ArgsCommand	lib/byebug/commands/var/args.rb	/^    class ArgsCommand < Command$/;"	c	class:Byebug.VarCommand
+Assertions	test/support/assertions.rb	/^  module Assertions$/;"	m	class:Minitest
+Attaching to a running program with `byebug`	GUIDE.md	/^### Attaching to a running program with `byebug`$/;"	h
+Attribution	code_of_conduct.md	/^## Attribution$/;"	h
+AutoirbSetting	lib/byebug/settings/autoirb.rb	/^  class AutoirbSetting < Setting$/;"	c	class:Byebug
+AutolistSetting	lib/byebug/settings/autolist.rb	/^  class AutolistSetting < Setting$/;"	c	class:Byebug
+AutoprySetting	lib/byebug/settings/autopry.rb	/^  class AutoprySetting < Setting$/;"	c	class:Byebug
+AutosaveSetting	lib/byebug/settings/autosave.rb	/^  class AutosaveSetting < Setting$/;"	c	class:Byebug
+BINDING	ext/byebug/byebug.h	/^  BINDING$/;"	e	enum:__anon3
+BP_METHOD_TYPE	ext/byebug/byebug.h	/^  BP_METHOD_TYPE$/;"	e	enum:bp_type
+BP_POS_TYPE	ext/byebug/byebug.h	/^  BP_POS_TYPE,$/;"	e	enum:bp_type
+BYEBUG	ext/byebug/byebug.h	2;"	d
+Base	lib/byebug/printers/base.rb	/^    class Base$/;"	c	class:Byebug.Printers
+BasenameSetting	lib/byebug/settings/basename.rb	/^  class BasenameSetting < Setting$/;"	c	class:Byebug
+BasicNextTest	test/commands/next_test.rb	/^  class BasicNextTest < TestCase$/;"	c	class:Byebug
+BasicSteppingTest	test/commands/step_test.rb	/^  class BasicSteppingTest < TestCase$/;"	c	class:Byebug
+BinHelper	lib/byebug/helpers/bin.rb	/^    module BinHelper$/;"	m	class:Byebug.Helpers
+BinHelperTest	test/helpers/bin_helper_test.rb	/^    class BinHelperTest < Minitest::Test$/;"	c	class:Byebug.Helpers
+BreakAtEmptyMethodsTest	test/commands/break_test.rb	/^  class BreakAtEmptyMethodsTest < TestCase$/;"	c
+BreakAtLinesTest	test/commands/break_test.rb	/^  class BreakAtLinesTest < TestCase$/;"	c
+BreakAtMethodsTest	test/commands/break_test.rb	/^  class BreakAtMethodsTest < TestCase$/;"	c	class:Byebug
+BreakCommand	lib/byebug/commands/break.rb	/^  class BreakCommand < Command$/;"	c	class:Byebug
+BreakWithByebugKeywordAtBlockEndTest	test/commands/break_test.rb	/^  class BreakWithByebugKeywordAtBlockEndTest < TestCase$/;"	c
+BreakWithByebugKeywordAtClassDefinitionEndTest	test/commands/break_test.rb	/^  class BreakWithByebugKeywordAtClassDefinitionEndTest < TestCase$/;"	c
+BreakWithByebugKeywordAtMethodEndTest	test/commands/break_test.rb	/^  class BreakWithByebugKeywordAtMethodEndTest < TestCase$/;"	c
+Breakpoint	lib/byebug/breakpoint.rb	/^  class Breakpoint$/;"	c	class:Byebug
+Breakpoints	ext/byebug/byebug.c	/^Breakpoints(VALUE self)$/;"	f	file:	signature:(VALUE self)
+BreakpointsCommand	lib/byebug/commands/disable/breakpoints.rb	/^    class BreakpointsCommand < Command$/;"	c	class:Byebug.DisableCommand
+BreakpointsCommand	lib/byebug/commands/enable/breakpoints.rb	/^    class BreakpointsCommand < Command$/;"	c	class:Byebug.EnableCommand
+BreakpointsCommand	lib/byebug/commands/info/breakpoints.rb	/^    class BreakpointsCommand < Command$/;"	c	class:Byebug.InfoCommand
+Bug Reports	CONTRIBUTING.md	/^## Bug Reports$/;"	h
+Build Status	README.md	/^## Build Status$/;"	h
+Byebug	README.md	/^# Byebug$/;"	h
+Byebug	lib/byebug/attacher.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/breakpoint.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/command.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/command_list.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/break.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/catch.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/condition.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/continue.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/debug.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/delete.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/disable.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/disable/breakpoints.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/disable/display.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/display.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/down.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/edit.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/enable.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/enable/breakpoints.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/enable/display.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/finish.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/frame.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/help.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/history.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/info.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/info/breakpoints.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/info/display.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/info/file.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/info/line.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/info/program.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/interrupt.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/irb.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/kill.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/list.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/method.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/next.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/pry.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/quit.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/restart.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/save.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/set.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/show.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/skip.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/source.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/step.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/thread.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/thread/current.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/thread/list.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/thread/resume.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/thread/stop.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/thread/switch.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/tracevar.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/undisplay.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/untracevar.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/up.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/var.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/var/all.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/var/args.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/var/const.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/var/global.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/var/instance.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/var/local.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/commands/where.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/context.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/core.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/errors.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/frame.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/bin.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/eval.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/file.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/frame.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/parse.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/path.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/reflection.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/string.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/thread.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/toggle.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/helpers/var.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/history.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/interface.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/interfaces/local_interface.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/interfaces/remote_interface.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/interfaces/script_interface.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/interfaces/test_interface.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/option_setter.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/printers/base.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/printers/plain.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/processors/command_processor.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/processors/control_processor.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/processors/post_mortem_processor.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/processors/script_processor.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/remote.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/remote/client.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/remote/server.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/runner.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/setting.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/autoirb.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/autolist.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/autopry.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/autosave.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/basename.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/callstyle.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/fullpath.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/histfile.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/histsize.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/linetrace.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/listsize.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/post_mortem.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/savefile.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/stack_on_error.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/settings/width.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/source_file_formatter.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/subcommands.rb	/^module Byebug$/;"	m
+Byebug	lib/byebug/version.rb	/^module Byebug$/;"	m
+Byebug	test/changelog_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/break_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/catch_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/condition_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/continue_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/debug_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/delete_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/disable_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/display_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/down_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/edit_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/enable_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/finish_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/frame_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/help_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/history_test.rb	/^  module Byebug$/;"	m
+Byebug	test/commands/info_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/interrupt_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/irb_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/kill_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/list_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/method_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/next_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/pry_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/quit_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/restart_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/save_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/set_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/show_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/skip_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/source_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/step_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/thread_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/tracevar_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/undisplay_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/up_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/var_test.rb	/^module Byebug$/;"	m
+Byebug	test/commands/where_test.rb	/^module Byebug$/;"	m
+Byebug	test/debugger_alias_test.rb	/^module Byebug$/;"	m
+Byebug	test/helpers/bin_helper_test.rb	/^module Byebug$/;"	m
+Byebug	test/interface_test.rb	/^module Byebug$/;"	m
+Byebug	test/interfaces/local_interface_test.rb	/^module Byebug$/;"	m
+Byebug	test/interfaces/script_interface_test.rb	/^module Byebug$/;"	m
+Byebug	test/minitest_runner.rb	/^module Byebug$/;"	m
+Byebug	test/minitest_runner_test.rb	/^module Byebug$/;"	m
+Byebug	test/post_mortem_test.rb	/^module Byebug$/;"	m
+Byebug	test/printers/plain_test.rb	/^module Byebug$/;"	m
+Byebug	test/processors/command_processor_test.rb	/^        module Byebug$/;"	m	class:ProcessorEvaluationAndThreadsTest.program
+Byebug	test/processors/command_processor_test.rb	/^module Byebug$/;"	m
+Byebug	test/processors/script_processor_test.rb	/^module Byebug$/;"	m
+Byebug	test/rc_test.rb	/^module Byebug$/;"	m
+Byebug	test/remote_debugging_test.rb	/^module Byebug$/;"	m
+Byebug	test/remote_shortcut_test.rb	/^module Byebug$/;"	m
+Byebug	test/runner_against_program_with_byebug_call_test.rb	/^module Byebug$/;"	m
+Byebug	test/runner_against_valid_program_test.rb	/^module Byebug$/;"	m
+Byebug	test/runner_without_target_program_test.rb	/^module Byebug$/;"	m
+Byebug	test/support/matchers.rb	/^module Byebug$/;"	m
+Byebug	test/support/remote_debugging_tests.rb	/^module Byebug$/;"	m
+Byebug	test/support/temporary.rb	/^module Byebug$/;"	m
+Byebug	test/support/test_case.rb	/^module Byebug$/;"	m
+Byebug	test/support/utils.rb	/^        module Byebug$/;"	m	class:Byebug.TestUtils.minimal_program
+Byebug	test/support/utils.rb	/^module Byebug$/;"	m
+Byebug Command Reference	GUIDE.md	/^## Byebug Command Reference$/;"	h
+Byebug as a C-extension	CONTRIBUTING.md	/^## Byebug as a C-extension$/;"	h
+Byebug default options	GUIDE.md	/^### Byebug default options$/;"	h
+Byebug's REPL and threads	Ruby_Grant_2014_Report.md	/^### Byebug's REPL and threads$/;"	h
+Byebug's commands	README.md	/^## Byebug's commands$/;"	h
+CALL_EVENT_SETUP	ext/byebug/byebug.c	162;"	d	file:
+CHANGELOG.md	CHANGELOG.md	1;"	F
+CLASS	ext/byebug/byebug.h	/^  CLASS,$/;"	e	enum:__anon3
+CLangFormatLinter	tasks/linter.rb	/^class CLangFormatLinter$/;"	c
+COMPILERS	docker/manager.rb	/^    COMPILERS = %w[$/;"	c
+CONTRIBUTING	CONTRIBUTING.md	/^# CONTRIBUTING$/;"	h
+CONTRIBUTING.md	CONTRIBUTING.md	1;"	F
+CTX_FL_DEAD	ext/byebug/byebug.h	11;"	d
+CTX_FL_IGNORE	ext/byebug/byebug.h	12;"	d
+CTX_FL_IGNORE_STEPS	ext/byebug/byebug.h	17;"	d
+CTX_FL_SET	ext/byebug/byebug.h	21;"	d
+CTX_FL_STOP_ON_RET	ext/byebug/byebug.h	16;"	d
+CTX_FL_SUSPEND	ext/byebug/byebug.h	13;"	d
+CTX_FL_TEST	ext/byebug/byebug.h	20;"	d
+CTX_FL_TRACING	ext/byebug/byebug.h	14;"	d
+CTX_FL_UNSET	ext/byebug/byebug.h	26;"	d
+CTX_FL_WAS_RUNNING	ext/byebug/byebug.h	15;"	d
+CTX_STOP_BREAKPOINT	ext/byebug/byebug.h	/^  CTX_STOP_BREAKPOINT,$/;"	e	enum:__anon1
+CTX_STOP_CATCHPOINT	ext/byebug/byebug.h	/^  CTX_STOP_CATCHPOINT$/;"	e	enum:__anon1
+CTX_STOP_NONE	ext/byebug/byebug.h	/^  CTX_STOP_NONE,$/;"	e	enum:__anon1
+CTX_STOP_STEP	ext/byebug/byebug.h	/^  CTX_STOP_STEP,$/;"	e	enum:__anon1
+Calling byebug from inside your program	GUIDE.md	/^### Calling byebug from inside your program$/;"	h
+CallstyleSetting	lib/byebug/settings/callstyle.rb	/^  class CallstyleSetting < Setting$/;"	c	class:Byebug
+CatchCommand	lib/byebug/commands/catch.rb	/^  class CatchCommand < Command$/;"	c	class:Byebug
+CatchTest	test/commands/catch_test.rb	/^  class CatchTest < TestCase$/;"	c	class:Byebug
+Catchpoints	ext/byebug/byebug.c	/^Catchpoints(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Changed	CHANGELOG.md	/^### Changed$/;"	h
+Changelog	CHANGELOG.md	/^# Changelog$/;"	h
+ChangelogTest	test/changelog_test.rb	/^  class ChangelogTest < Minitest::Test$/;"	c	class:Byebug
+ClassMethods	lib/byebug/subcommands.rb	/^    module ClassMethods$/;"	m	class:Byebug.Subcommands
+Client	lib/byebug/remote/client.rb	/^    class Client$/;"	c	class:Byebug.Remote
+Code style	CONTRIBUTING.md	/^## Code style$/;"	h
+Command	lib/byebug/command.rb	/^  class Command$/;"	c	class:Byebug
+Command Files	GUIDE.md	/^### Command Files$/;"	h
+Command Help	GUIDE.md	/^### Command Help$/;"	h
+Command Output	GUIDE.md	/^### Command Output$/;"	h
+Command Syntax	GUIDE.md	/^### Command Syntax$/;"	h
+CommandList	lib/byebug/command_list.rb	/^  class CommandList$/;"	c	class:Byebug
+CommandNotFound	lib/byebug/errors.rb	/^  class CommandNotFound < NoMethodError$/;"	c	class:Byebug
+CommandProcessor	lib/byebug/processors/command_processor.rb	/^  class CommandProcessor$/;"	c	class:Byebug
+ConditionCommand	lib/byebug/commands/condition.rb	/^  class ConditionCommand < Command$/;"	c	class:Byebug
+ConditionTest	test/commands/condition_test.rb	/^  class ConditionTest < TestCase$/;"	c	class:Byebug
+ConstCommand	lib/byebug/commands/var/const.rb	/^    class ConstCommand < Command$/;"	c	class:Byebug.VarCommand
+Context	lib/byebug/context.rb	/^  class Context$/;"	c	class:Byebug
+Context_backtrace	ext/byebug/context.c	/^Context_backtrace(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Context_dead	ext/byebug/context.c	/^Context_dead(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Context_frame_binding	ext/byebug/context.c	/^Context_frame_binding(int argc, VALUE *argv, VALUE self)$/;"	f	file:	signature:(int argc, VALUE *argv, VALUE self)
+Context_frame_class	ext/byebug/context.c	/^Context_frame_class(int argc, VALUE *argv, VALUE self)$/;"	f	file:	signature:(int argc, VALUE *argv, VALUE self)
+Context_frame_file	ext/byebug/context.c	/^Context_frame_file(int argc, VALUE *argv, VALUE self)$/;"	f	file:	signature:(int argc, VALUE *argv, VALUE self)
+Context_frame_line	ext/byebug/context.c	/^Context_frame_line(int argc, VALUE *argv, VALUE self)$/;"	f	file:	signature:(int argc, VALUE *argv, VALUE self)
+Context_frame_method	ext/byebug/context.c	/^Context_frame_method(int argc, VALUE *argv, VALUE self)$/;"	f	file:	signature:(int argc, VALUE *argv, VALUE self)
+Context_frame_self	ext/byebug/context.c	/^Context_frame_self(int argc, VALUE *argv, VALUE self)$/;"	f	file:	signature:(int argc, VALUE *argv, VALUE self)
+Context_ignored	ext/byebug/context.c	/^Context_ignored(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Context_is_suspended	ext/byebug/context.c	/^Context_is_suspended(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Context_resume	ext/byebug/context.c	/^Context_resume(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Context_set_tracing	ext/byebug/context.c	/^Context_set_tracing(VALUE self, VALUE value)$/;"	f	file:	signature:(VALUE self, VALUE value)
+Context_step_into	ext/byebug/context.c	/^Context_step_into(int argc, VALUE *argv, VALUE self)$/;"	f	file:	signature:(int argc, VALUE *argv, VALUE self)
+Context_step_out	ext/byebug/context.c	/^Context_step_out(int argc, VALUE *argv, VALUE self)$/;"	f	file:	signature:(int argc, VALUE *argv, VALUE self)
+Context_step_over	ext/byebug/context.c	/^Context_step_over(int argc, VALUE *argv, VALUE self)$/;"	f	file:	signature:(int argc, VALUE *argv, VALUE self)
+Context_stop_reason	ext/byebug/context.c	/^Context_stop_reason(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Context_suspend	ext/byebug/context.c	/^Context_suspend(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Context_switch	ext/byebug/context.c	/^Context_switch(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Context_thnum	ext/byebug/context.c	/^Context_thnum(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Context_thread	ext/byebug/context.c	/^Context_thread(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Context_tracing	ext/byebug/context.c	/^Context_tracing(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Contexts	ext/byebug/byebug.c	/^Contexts(VALUE self)$/;"	f	file:	signature:(VALUE self)
+ContinueCommand	lib/byebug/commands/continue.rb	/^  class ContinueCommand < Command$/;"	c	class:Byebug
+ContinueTest	test/commands/continue_test.rb	/^  class ContinueTest < TestCase$/;"	c	class:Byebug
+ContinueUnconditionallyWithByebugCallsTest	test/commands/continue_test.rb	/^  class ContinueUnconditionallyWithByebugCallsTest < TestCase$/;"	c
+Contribute	README.md	/^## Contribute$/;"	h
+Contributor Covenant Code of Conduct	code_of_conduct.md	/^# Contributor Covenant Code of Conduct$/;"	h
+Control Commands: quit, restart, source	GUIDE.md	/^### Control Commands: quit, restart, source$/;"	h
+ControlProcessor	lib/byebug/processors/control_processor.rb	/^  class ControlProcessor < CommandProcessor$/;"	c	class:Byebug
+Credits	README.md	/^## Credits$/;"	h
+CurrentCommand	lib/byebug/commands/thread/current.rb	/^    class CurrentCommand < Command$/;"	c	class:Byebug.ThreadCommand
+Current_context	ext/byebug/byebug.c	/^Current_context(VALUE self)$/;"	f	file:	signature:(VALUE self)
+DEFAULT	lib/byebug/setting.rb	/^    DEFAULT = false$/;"	c
+DEFAULT	lib/byebug/settings/autoirb.rb	/^    DEFAULT = 0$/;"	c
+DEFAULT	lib/byebug/settings/autolist.rb	/^    DEFAULT = 1$/;"	c
+DEFAULT	lib/byebug/settings/autopry.rb	/^    DEFAULT = 0$/;"	c
+DEFAULT	lib/byebug/settings/autosave.rb	/^    DEFAULT = true$/;"	c
+DEFAULT	lib/byebug/settings/callstyle.rb	/^    DEFAULT = "long"$/;"	c
+DEFAULT	lib/byebug/settings/fullpath.rb	/^    DEFAULT = true$/;"	c
+DEFAULT	lib/byebug/settings/histfile.rb	/^    DEFAULT = File.expand_path(".byebug_history")$/;"	c
+DEFAULT	lib/byebug/settings/histsize.rb	/^    DEFAULT = 256$/;"	c
+DEFAULT	lib/byebug/settings/listsize.rb	/^    DEFAULT = 10$/;"	c
+DEFAULT	lib/byebug/settings/savefile.rb	/^    DEFAULT = File.expand_path("#{ENV['HOME'] || '.'}\/.byebug_save")$/;"	c
+DEFAULT	lib/byebug/settings/width.rb	/^    DEFAULT = 160$/;"	c
+DebugCommand	lib/byebug/commands/debug.rb	/^  class DebugCommand < Command$/;"	c	class:Byebug
+Debug_load	ext/byebug/byebug.c	/^Debug_load(int argc, VALUE *argv, VALUE self)$/;"	f	file:	signature:(int argc, VALUE *argv, VALUE self)
+DebuggerAliasTest	test/debugger_alias_test.rb	/^  class DebuggerAliasTest < Minitest::Test$/;"	c	class:Byebug
+Debugging Oddities: How debugging Ruby may be different from other languages	GUIDE.md	/^### Debugging Oddities: How debugging Ruby may be different from other languages$/;"	h
+Debugging remote programs	GUIDE.md	/^## Debugging remote programs$/;"	h
+DeleteCommand	lib/byebug/commands/delete.rb	/^  class DeleteCommand < Command$/;"	c	class:Byebug
+DeleteTest	test/commands/delete_test.rb	/^  class DeleteTest < TestCase$/;"	c	class:Byebug
+Development dependencies	CONTRIBUTING.md	/^## Development dependencies$/;"	h
+DisableCommand	lib/byebug/commands/disable.rb	/^  class DisableCommand < Command$/;"	c	class:Byebug
+DisableCommand	lib/byebug/commands/disable/breakpoints.rb	/^  class DisableCommand < Command$/;"	c	class:Byebug
+DisableCommand	lib/byebug/commands/disable/display.rb	/^  class DisableCommand < Command$/;"	c	class:Byebug
+DisableTest	test/commands/disable_test.rb	/^  class DisableTest < TestCase$/;"	c	class:Byebug
+Display Commands: display, undisplay	GUIDE.md	/^### Display Commands: display, undisplay$/;"	h
+DisplayCommand	lib/byebug/commands/disable/display.rb	/^    class DisplayCommand < Command$/;"	c	class:Byebug.DisableCommand
+DisplayCommand	lib/byebug/commands/display.rb	/^  class DisplayCommand < Command$/;"	c	class:Byebug
+DisplayCommand	lib/byebug/commands/enable/display.rb	/^    class DisplayCommand < Command$/;"	c	class:Byebug.EnableCommand
+DisplayCommand	lib/byebug/commands/info/display.rb	/^    class DisplayCommand < Command$/;"	c	class:Byebug.InfoCommand
+DisplayTest	test/commands/display_test.rb	/^  class DisplayTest < TestCase$/;"	c	class:Byebug
+Docker	docker/manager.rb	/^module Docker$/;"	m
+DownCommand	lib/byebug/commands/down.rb	/^  class DownCommand < Command$/;"	c	class:Byebug
+DownTest	test/commands/down_test.rb	/^  class DownTest < TestCase$/;"	c	class:Byebug
+EOF_ALIAS	lib/byebug/interfaces/local_interface.rb	/^    EOF_ALIAS = "continue"$/;"	c
+EVENT_SETUP	ext/byebug/byebug.c	139;"	d	file:
+EVENT_TEARDOWN	ext/byebug/byebug.c	137;"	d	file:
+EditCommand	lib/byebug/commands/edit.rb	/^  class EditCommand < Command$/;"	c	class:Byebug
+EditTest	test/commands/edit_test.rb	/^  class EditTest < TestCase$/;"	c	class:Byebug
+Editing Source files: edit	GUIDE.md	/^### Editing Source files: edit$/;"	h
+EnableCommand	lib/byebug/commands/enable.rb	/^  class EnableCommand < Command$/;"	c	class:Byebug
+EnableCommand	lib/byebug/commands/enable/breakpoints.rb	/^  class EnableCommand < Command$/;"	c	class:Byebug
+EnableCommand	lib/byebug/commands/enable/display.rb	/^  class EnableCommand < Command$/;"	c	class:Byebug
+EnableTest	test/commands/enable_test.rb	/^  class EnableTest < TestCase$/;"	c	class:Byebug
+Enforcement	code_of_conduct.md	/^## Enforcement$/;"	h
+Enumerator for primes	GUIDE.md	/^# Enumerator for primes$/;"	h
+EvalHelper	lib/byebug/helpers/eval.rb	/^    module EvalHelper$/;"	m	class:Byebug.Helpers
+Evaluation of expressions: irb, pry	GUIDE.md	/^### Evaluation of expressions: irb, pry$/;"	h
+Examining Program Source Files: list	GUIDE.md	/^### Examining Program Source Files: list$/;"	h
+Exception	lib/byebug/core.rb	/^class Exception$/;"	c
+ExecutableLinter	tasks/linter.rb	/^class ExecutableLinter$/;"	c
+Expected behavior	.github/ISSUE_TEMPLATE.md	/^## Expected behavior$/;"	h
+FRAME_SETUP	ext/byebug/context.c	207;"	d	file:
+FileCommand	lib/byebug/commands/info/file.rb	/^    class FileCommand < Command$/;"	c	class:Byebug.InfoCommand
+FileHelper	lib/byebug/helpers/file.rb	/^    module FileHelper$/;"	m	class:Byebug.Helpers
+FinishAfterReturnTest	test/commands/finish_test.rb	/^  class FinishAfterReturnTest < TestCase$/;"	c	class:Byebug
+FinishBeforeReturnTest	test/commands/finish_test.rb	/^  class FinishBeforeReturnTest < TestCase$/;"	c
+FinishCommand	lib/byebug/commands/finish.rb	/^  class FinishCommand < Command$/;"	c	class:Byebug
+FinishInsideAutoloadedFilesTest	test/commands/finish_test.rb	/^  class FinishInsideAutoloadedFilesTest < TestCase$/;"	c
+First Steps	GUIDE.md	/^### First Steps$/;"	h
+Fixed	CHANGELOG.md	/^### Fixed$/;"	h
+For enterprise	README.md	/^## For enterprise$/;"	h
+Frame	lib/byebug/frame.rb	/^  class Frame$/;"	c	class:Byebug
+FrameCommand	lib/byebug/commands/frame.rb	/^  class FrameCommand < Command$/;"	c	class:Byebug
+FrameHelper	lib/byebug/helpers/frame.rb	/^    module FrameHelper$/;"	m	class:Byebug.Helpers
+FrameTest	test/commands/frame_test.rb	/^  class FrameTest < TestCase$/;"	c	class:Byebug
+From the command line	README.md	/^### From the command line$/;"	h
+From within the Ruby code	README.md	/^### From within the Ruby code$/;"	h
+FullpathSetting	lib/byebug/settings/fullpath.rb	/^  class FullpathSetting < Setting$/;"	c	class:Byebug
+Funding	README.md	/^## Funding$/;"	h
+Future work	Ruby_Grant_2014_Report.md	/^## Future work$/;"	h
+GUIDE	GUIDE.md	/^# GUIDE$/;"	h
+GUIDE.md	GUIDE.md	1;"	F
+Getting Started	README.md	/^## Getting Started$/;"	h
+Getting in & out	GUIDE.md	/^## Getting in & out$/;"	h
+GlobalCommand	lib/byebug/commands/var/global.rb	/^    class GlobalCommand < Command$/;"	c	class:Byebug.VarCommand
+HIT_COND_EQ	ext/byebug/byebug.h	/^  HIT_COND_EQ,$/;"	e	enum:hit_condition
+HIT_COND_GE	ext/byebug/byebug.h	/^  HIT_COND_GE,$/;"	e	enum:hit_condition
+HIT_COND_MOD	ext/byebug/byebug.h	/^  HIT_COND_MOD$/;"	e	enum:hit_condition
+HIT_COND_NONE	ext/byebug/byebug.h	/^  HIT_COND_NONE,$/;"	e	enum:hit_condition
+HelpAloneTest	test/commands/help_test.rb	/^  class HelpAloneTest < TestCase$/;"	c	class:Byebug
+HelpCommand	lib/byebug/commands/help.rb	/^  class HelpCommand < Command$/;"	c	class:Byebug
+HelpWithArgsTest	test/commands/help_test.rb	/^  class HelpWithArgsTest < TestCase$/;"	c
+Helpers	lib/byebug/helpers/bin.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	lib/byebug/helpers/eval.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	lib/byebug/helpers/file.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	lib/byebug/helpers/frame.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	lib/byebug/helpers/parse.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	lib/byebug/helpers/path.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	lib/byebug/helpers/reflection.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	lib/byebug/helpers/string.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	lib/byebug/helpers/thread.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	lib/byebug/helpers/toggle.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	lib/byebug/helpers/var.rb	/^  module Helpers$/;"	m	class:Byebug
+Helpers	test/helpers/bin_helper_test.rb	/^  module Helpers$/;"	m	class:Byebug
+HistfileSetting	lib/byebug/settings/histfile.rb	/^  class HistfileSetting < Setting$/;"	c	class:Byebug
+History	lib/byebug/history.rb	/^  class History$/;"	c	class:Byebug
+HistoryCommand	lib/byebug/commands/history.rb	/^  class HistoryCommand < Command$/;"	c	class:Byebug
+HistoryTest	test/commands/history_test.rb	/^    class HistoryTest < TestCase$/;"	c	class:Byebug
+HistsizeSetting	lib/byebug/settings/histsize.rb	/^  class HistsizeSetting < Setting$/;"	c	class:Byebug
+ISSUE_TEMPLATE.md	.github/ISSUE_TEMPLATE.md	1;"	F
+IS_STARTED	ext/byebug/byebug.c	66;"	d	file:
+InfoCommand	lib/byebug/commands/info.rb	/^  class InfoCommand < Command$/;"	c	class:Byebug
+InfoCommand	lib/byebug/commands/info/breakpoints.rb	/^  class InfoCommand < Command$/;"	c	class:Byebug
+InfoCommand	lib/byebug/commands/info/display.rb	/^  class InfoCommand < Command$/;"	c	class:Byebug
+InfoCommand	lib/byebug/commands/info/file.rb	/^  class InfoCommand < Command$/;"	c	class:Byebug
+InfoCommand	lib/byebug/commands/info/line.rb	/^  class InfoCommand < Command$/;"	c	class:Byebug
+InfoCommand	lib/byebug/commands/info/program.rb	/^  class InfoCommand < Command$/;"	c	class:Byebug
+InfoCrashedTest	test/commands/info_test.rb	/^  class InfoCrashedTest < TestCase$/;"	c
+InfoFileTest	test/commands/info_test.rb	/^  class InfoFileTest < TestCase$/;"	c
+InfoTest	test/commands/info_test.rb	/^  class InfoTest < TestCase$/;"	c	class:Byebug
+Init_byebug	ext/byebug/byebug.c	/^Init_byebug()$/;"	f
+Init_byebug_breakpoint	ext/byebug/breakpoint.c	/^Init_byebug_breakpoint(VALUE mByebug)$/;"	f	signature:(VALUE mByebug)
+Init_byebug_breakpoint	ext/byebug/byebug.h	/^extern void Init_byebug_breakpoint(VALUE mByebug);$/;"	p	signature:(VALUE mByebug)
+Init_byebug_context	ext/byebug/byebug.h	/^extern void Init_byebug_context(VALUE mByebug);$/;"	p	signature:(VALUE mByebug)
+Init_byebug_context	ext/byebug/context.c	/^Init_byebug_context(VALUE mByebug)$/;"	f	signature:(VALUE mByebug)
+Init_threads_table	ext/byebug/byebug.h	/^extern void Init_threads_table(VALUE mByebug);$/;"	p	signature:(VALUE mByebug)
+Init_threads_table	ext/byebug/threads.c	/^Init_threads_table(VALUE mByebug)$/;"	f	signature:(VALUE mByebug)
+Install	README.md	/^## Install$/;"	h
+InstanceCommand	lib/byebug/commands/var/instance.rb	/^    class InstanceCommand < Command$/;"	c	class:Byebug.VarCommand
+Interface	lib/byebug/interface.rb	/^  class Interface$/;"	c	class:Byebug
+InterfaceTest	test/interface_test.rb	/^  class InterfaceTest < Minitest::Test$/;"	c	class:Byebug
+InterruptCommand	lib/byebug/commands/interrupt.rb	/^  class InterruptCommand < Command$/;"	c	class:Byebug
+InterruptTest	test/commands/interrupt_test.rb	/^  class InterruptTest < TestCase$/;"	c	class:Byebug
+Introduction	GUIDE.md	/^## Introduction$/;"	h
+IrbCommand	lib/byebug/commands/irb.rb	/^  class IrbCommand < Command$/;"	c	class:Byebug
+IrbTest	test/commands/irb_test.rb	/^  class IrbTest < TestCase$/;"	c	class:Byebug
+Kernel	lib/byebug/attacher.rb	/^module Kernel$/;"	m
+KillCommand	lib/byebug/commands/kill.rb	/^  class KillCommand < Command$/;"	c	class:Byebug
+KillTest	test/commands/kill_test.rb	/^  class KillTest < TestCase$/;"	c	class:Byebug
+LINE_EDITORS	docker/manager.rb	/^    LINE_EDITORS = %w[$/;"	c
+LOCATION	ext/byebug/byebug.h	/^  LOCATION,$/;"	e	enum:__anon3
+LineCommand	lib/byebug/commands/info/line.rb	/^    class LineCommand < Command$/;"	c	class:Byebug.InfoCommand
+LinetraceSetting	lib/byebug/settings/linetrace.rb	/^  class LinetraceSetting < Setting$/;"	c	class:Byebug
+LinterMixin	tasks/linter.rb	/^module LinterMixin$/;"	m
+ListCommand	lib/byebug/commands/list.rb	/^  class ListCommand < Command$/;"	c	class:Byebug
+ListCommand	lib/byebug/commands/thread/list.rb	/^    class ListCommand < Command$/;"	c	class:Byebug.ThreadCommand
+ListTest	test/commands/list_test.rb	/^  class ListTest < TestCase$/;"	c	class:Byebug
+ListsizeSetting	lib/byebug/settings/listsize.rb	/^  class ListsizeSetting < Setting$/;"	c	class:Byebug
+LocalCommand	lib/byebug/commands/var/local.rb	/^    class LocalCommand < Command$/;"	c	class:Byebug.VarCommand
+LocalInterface	lib/byebug/interfaces/local_interface.rb	/^  class LocalInterface < Interface$/;"	c	class:Byebug
+LocalInterfaceTest	test/interfaces/local_interface_test.rb	/^  class LocalInterfaceTest < TestCase$/;"	c	class:Byebug
+Lock	ext/byebug/threads.c	/^Lock(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Manager	docker/manager.rb	/^  class Manager$/;"	c	class:Docker
+Mantaining a global thread list	Ruby_Grant_2014_Report.md	/^### Mantaining a global thread list$/;"	h
+MethodCommand	lib/byebug/commands/method.rb	/^  class MethodCommand < Command$/;"	c	class:Byebug
+MethodTest	test/commands/method_test.rb	/^  class MethodTest < TestCase$/;"	c	class:Byebug
+Minitest	test/support/assertions.rb	/^module Minitest$/;"	m
+MinitestRunner	test/minitest_runner.rb	/^  class MinitestRunner$/;"	c	class:Byebug
+MinitestRunnerTest	test/minitest_runner_test.rb	/^  class MinitestRunnerTest < TestCase$/;"	c	class:Byebug
+MissedArgument	lib/byebug/printers/base.rb	/^      class MissedArgument < StandardError; end$/;"	c	class:Byebug.Printers.Base
+MissedPath	lib/byebug/printers/base.rb	/^      class MissedPath < StandardError; end$/;"	c	class:Byebug.Printers.Base
+MoreThanOneStepTest	test/commands/step_test.rb	/^  class MoreThanOneStepTest < TestCase$/;"	c
+Motivation	Ruby_Grant_2014_Report.md	/^## Motivation$/;"	h
+NextAndDefineMethodTest	test/commands/next_test.rb	/^  class NextAndDefineMethodTest < TestCase$/;"	c
+NextBacktracesTest	test/commands/next_test.rb	/^  class NextBacktracesTest < TestCase$/;"	c
+NextCommand	lib/byebug/commands/next.rb	/^  class NextCommand < Command$/;"	c	class:Byebug
+NextGoingUpFramesTest	test/commands/next_test.rb	/^  class NextGoingUpFramesTest < TestCase$/;"	c
+NextRescueTest	test/commands/next_test.rb	/^  class NextRescueTest < TestCase$/;"	c
+NextWhenReturnInsideLoopInsideInitializeTest	test/commands/next_test.rb	/^  class NextWhenReturnInsideLoopInsideInitializeTest < TestCase$/;"	c
+OptionSetter	lib/byebug/option_setter.rb	/^  class OptionSetter$/;"	c	class:Byebug
+Our Pledge	code_of_conduct.md	/^## Our Pledge$/;"	h
+Our Responsibilities	code_of_conduct.md	/^## Our Responsibilities$/;"	h
+Our Standards	code_of_conduct.md	/^## Our Standards$/;"	h
+PORT	lib/byebug/remote.rb	/^  PORT = 8989 unless defined?(PORT)$/;"	c
+ParseHelper	lib/byebug/helpers/parse.rb	/^    module ParseHelper$/;"	m	class:Byebug.Helpers
+PathHelper	lib/byebug/helpers/path.rb	/^    module PathHelper$/;"	m	class:Byebug.Helpers
+Plain	lib/byebug/printers/plain.rb	/^    class Plain < Base$/;"	c	class:Byebug.Printers
+PostMortemProcessor	lib/byebug/processors/post_mortem_processor.rb	/^  class PostMortemProcessor < CommandProcessor$/;"	c	class:Byebug
+PostMortemSetting	lib/byebug/settings/post_mortem.rb	/^  class PostMortemSetting < Setting$/;"	c	class:Byebug
+PostMortemTest	test/post_mortem_test.rb	/^  class PostMortemTest < TestCase$/;"	c	class:Byebug
+Post_mortem	ext/byebug/byebug.c	/^Post_mortem(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Printers	lib/byebug/printers/base.rb	/^  module Printers$/;"	m	class:Byebug
+Printers	lib/byebug/printers/plain.rb	/^  module Printers$/;"	m	class:Byebug
+PrintersPlainTest	test/printers/plain_test.rb	/^  class PrintersPlainTest < TestCase$/;"	c	class:Byebug
+Printing the Stack: `where` command	GUIDE.md	/^### Printing the Stack: `where` command$/;"	h
+Printing variables: var	GUIDE.md	/^### Printing variables: var$/;"	h
+Problem description	.github/ISSUE_TEMPLATE.md	/^## Problem description$/;"	h
+ProcessorAutocommandsTest	test/processors/command_processor_test.rb	/^  class ProcessorAutocommandsTest < TestCase$/;"	c
+ProcessorBaseTest	test/processors/command_processor_test.rb	/^  class ProcessorBaseTest < TestCase$/;"	c	class:Byebug
+ProcessorEvaluationAndBreakpointsTest	test/processors/command_processor_test.rb	/^  class ProcessorEvaluationAndBreakpointsTest < TestCase$/;"	c
+ProcessorEvaluationAndThreadsTest	test/processors/command_processor_test.rb	/^  class ProcessorEvaluationAndThreadsTest < TestCase$/;"	c
+ProcessorUnknownInputTest	test/processors/command_processor_test.rb	/^  class ProcessorUnknownInputTest < TestCase$/;"	c
+ProgramCommand	lib/byebug/commands/info/program.rb	/^    class ProgramCommand < Command$/;"	c	class:Byebug.InfoCommand
+PryCommand	lib/byebug/commands/pry.rb	/^  class PryCommand < Command$/;"	c	class:Byebug
+PryTest	test/commands/pry_test.rb	/^  class PryTest < TestCase$/;"	c	class:Byebug
+QuitCommand	lib/byebug/commands/quit.rb	/^  class QuitCommand < Command$/;"	c	class:Byebug
+QuitTest	test/commands/quit_test.rb	/^  class QuitTest < TestCase$/;"	c	class:Byebug
+Quitting byebug	GUIDE.md	/^### Quitting byebug$/;"	h
+README.md	README.md	1;"	F
+RETURN_EVENT_SETUP	ext/byebug/byebug.c	166;"	d	file:
+RETURN_EVENT_TEARDOWN	ext/byebug/byebug.c	172;"	d	file:
+Raised_exception	ext/byebug/byebug.c	/^Raised_exception(VALUE self)$/;"	f	file:	signature:(VALUE self)
+RcTest	test/rc_test.rb	/^  class RcTest < TestCase$/;"	c	class:Byebug
+ReflectionHelper	lib/byebug/helpers/reflection.rb	/^    module ReflectionHelper$/;"	m	class:Byebug.Helpers
+Related projects	README.md	/^## Related projects$/;"	h
+Remote	lib/byebug/remote/client.rb	/^  module Remote$/;"	m	class:Byebug
+Remote	lib/byebug/remote/server.rb	/^  module Remote$/;"	m	class:Byebug
+RemoteDebuggingTest	test/remote_debugging_test.rb	/^  class RemoteDebuggingTest < TestCase$/;"	c	class:Byebug
+RemoteDebuggingTests	test/support/remote_debugging_tests.rb	/^  module RemoteDebuggingTests$/;"	m	class:Byebug
+RemoteInterface	lib/byebug/interfaces/remote_interface.rb	/^  class RemoteInterface < Interface$/;"	c	class:Byebug
+RemoteShortcutTest	test/remote_shortcut_test.rb	/^  class RemoteShortcutTest < TestCase$/;"	c	class:Byebug
+Removed	CHANGELOG.md	/^### Removed$/;"	h
+Requirements	README.md	/^## Requirements$/;"	h
+RestartCommand	lib/byebug/commands/restart.rb	/^  class RestartCommand < Command$/;"	c	class:Byebug
+RestartTest	test/commands/restart_test.rb	/^  class RestartTest < TestCase$/;"	c	class:Byebug
+Restarting Byebug	GUIDE.md	/^### Restarting Byebug$/;"	h
+ResumeCommand	lib/byebug/commands/thread/resume.rb	/^    class ResumeCommand < Command$/;"	c	class:Byebug.ThreadCommand
+Ruby_Grant_2014_Report.md	Ruby_Grant_2014_Report.md	1;"	F
+Runner	lib/byebug/runner.rb	/^  class Runner$/;"	c	class:Byebug
+RunnerAgainstProgramWithByebugCallTest	test/runner_against_program_with_byebug_call_test.rb	/^  class RunnerAgainstProgramWithByebugCallTest < TestCase$/;"	c	class:Byebug
+RunnerAgainstValidProgramTest	test/runner_against_valid_program_test.rb	/^  class RunnerAgainstValidProgramTest < TestCase$/;"	c	class:Byebug
+RunnerWithoutTargetProgramTest	test/runner_without_target_program_test.rb	/^  class RunnerWithoutTargetProgramTest < TestCase$/;"	c	class:Byebug
+Running the test suite	CONTRIBUTING.md	/^## Running the test suite$/;"	h
+Running:	GUIDE.md	/^# Running:$/;"	h
+SELF	ext/byebug/byebug.h	/^  SELF,$/;"	e	enum:__anon3
+SEPARATOR	lib/byebug/printers/base.rb	/^      SEPARATOR = "."$/;"	c
+SOMECONST	test/commands/var_test.rb	/^         6:      SOMECONST = "foo" unless defined?(SOMECONST)$/;"	c
+SaveCommand	lib/byebug/commands/save.rb	/^  class SaveCommand < Command$/;"	c	class:Byebug
+SaveTest	test/commands/save_test.rb	/^  class SaveTest < TestCase$/;"	c	class:Byebug
+SavefileSetting	lib/byebug/settings/savefile.rb	/^  class SavefileSetting < Setting$/;"	c	class:Byebug
+Scope	code_of_conduct.md	/^## Scope$/;"	h
+ScriptInterface	lib/byebug/interfaces/script_interface.rb	/^  class ScriptInterface < Interface$/;"	c	class:Byebug
+ScriptInterfaceTest	test/interfaces/script_interface_test.rb	/^  class ScriptInterfaceTest < TestCase$/;"	c	class:Byebug
+ScriptProcessor	lib/byebug/processors/script_processor.rb	/^  class ScriptProcessor < CommandProcessor$/;"	c	class:Byebug
+ScriptProcessorTest	test/processors/script_processor_test.rb	/^  class ScriptProcessorTest < Minitest::Test$/;"	c	class:Byebug
+Second Sample Session: Delving Deeper	GUIDE.md	/^### Second Sample Session: Delving Deeper$/;"	h
+Security contact information	README.md	/^## Security contact information$/;"	h
+Selecting a frame: `up`, `down` and `frame` commands	GUIDE.md	/^### Selecting a frame: `up`, `down` and `frame` commands$/;"	h
+Semantic Versioning	README.md	/^## Semantic Versioning$/;"	h
+Server	lib/byebug/remote/server.rb	/^    class Server$/;"	c	class:Byebug.Remote
+SetCommand	lib/byebug/commands/set.rb	/^  class SetCommand < Command$/;"	c	class:Byebug
+SetTest	test/commands/set_test.rb	/^  class SetTest < TestCase$/;"	c	class:Byebug
+Set_post_mortem	ext/byebug/byebug.c	/^Set_post_mortem(VALUE self, VALUE value)$/;"	f	file:	signature:(VALUE self, VALUE value)
+Set_tracing	ext/byebug/byebug.c	/^Set_tracing(VALUE self, VALUE value)$/;"	f	file:	signature:(VALUE self, VALUE value)
+Set_verbose	ext/byebug/byebug.c	/^Set_verbose(VALUE self, VALUE value)$/;"	f	file:	signature:(VALUE self, VALUE value)
+Setting	lib/byebug/setting.rb	/^  class Setting$/;"	c	class:Byebug
+ShowCommand	lib/byebug/commands/show.rb	/^  class ShowCommand < Command$/;"	c	class:Byebug
+ShowTest	test/commands/show_test.rb	/^  class ShowTest < TestCase$/;"	c	class:Byebug
+SkipCommand	lib/byebug/commands/skip.rb	/^  class SkipCommand < Command$/;"	c	class:Byebug
+SkipTest	test/commands/skip_test.rb	/^  class SkipTest < TestCase$/;"	c	class:Byebug
+Solves the classic Towers of Hanoi puzzle.	GUIDE.md	/^# Solves the classic Towers of Hanoi puzzle.$/;"	h
+SourceCommand	lib/byebug/commands/source.rb	/^  class SourceCommand < Command$/;"	c	class:Byebug
+SourceFileFormatter	lib/byebug/source_file_formatter.rb	/^  class SourceFileFormatter$/;"	c	class:Byebug
+SourceTest	test/commands/source_test.rb	/^  class SourceTest < TestCase$/;"	c	class:Byebug
+SpecificInterface	test/interface_test.rb	/^  class SpecificInterface < Interface$/;"	c	class:Byebug
+Specifics of some commands	Ruby_Grant_2014_Report.md	/^### Specifics of some commands$/;"	h
+StackOnErrorSetting	lib/byebug/settings/stack_on_error.rb	/^  class StackOnErrorSetting < Setting$/;"	c	class:Byebug
+Start	ext/byebug/byebug.c	/^Start(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Started	ext/byebug/byebug.c	/^Started(VALUE self)$/;"	f	file:	signature:(VALUE self)
+Starting byebug	GUIDE.md	/^### Starting byebug$/;"	h
+StepCommand	lib/byebug/commands/step.rb	/^  class StepCommand < Command$/;"	c	class:Byebug
+SteppingBacktracesTest	test/commands/step_test.rb	/^  class SteppingBacktracesTest < TestCase$/;"	c
+Steps to reproduce the problem	.github/ISSUE_TEMPLATE.md	/^## Steps to reproduce the problem$/;"	h
+Stop	ext/byebug/byebug.c	/^Stop(VALUE self)$/;"	f	file:	signature:(VALUE self)
+StopCommand	lib/byebug/commands/thread/stop.rb	/^    class StopCommand < Command$/;"	c	class:Byebug.ThreadCommand
+Stoppable	ext/byebug/byebug.c	/^Stoppable(VALUE self)$/;"	f	file:	signature:(VALUE self)
+StringHelper	lib/byebug/helpers/string.rb	/^    module StringHelper$/;"	m	class:Byebug.Helpers
+Subcommands	lib/byebug/subcommands.rb	/^  module Subcommands$/;"	m	class:Byebug
+SubdebuggersTest	test/commands/debug_test.rb	/^  class SubdebuggersTest < TestCase$/;"	c	class:Byebug
+SwitchCommand	lib/byebug/commands/thread/switch.rb	/^    class SwitchCommand < Command$/;"	c	class:Byebug.ThreadCommand
+TabLinter	tasks/linter.rb	/^class TabLinter$/;"	c
+TestCase	test/support/test_case.rb	/^  class TestCase < Minitest::Test$/;"	c	class:Byebug
+TestInterface	lib/byebug/interfaces/test_interface.rb	/^  class TestInterface < Interface$/;"	c	class:Byebug
+TestMatchers	test/support/matchers.rb	/^  module TestMatchers$/;"	m	class:Byebug
+TestTemporary	test/support/temporary.rb	/^  module TestTemporary$/;"	m	class:Byebug
+TestUtils	test/support/utils.rb	/^  module TestUtils$/;"	m	class:Byebug
+The code	Ruby_Grant_2014_Report.md	/^## The code$/;"	h
+The feature	Ruby_Grant_2014_Report.md	/^## The feature$/;"	h
+The implementation	Ruby_Grant_2014_Report.md	/^## The implementation$/;"	h
+The n'th triangle number: triangle(n) = n*(n+1)/2 = 1 + 2 + ... + n	GUIDE.md	/^# The n'th triangle number: triangle(n) = n*(n+1)\/2 = 1 + 2 + ... + n$/;"	h
+The stack trace	GUIDE.md	/^### The stack trace$/;"	h
+Thread syncronization	Ruby_Grant_2014_Report.md	/^### Thread syncronization$/;"	h
+ThreadCommand	lib/byebug/commands/thread.rb	/^  class ThreadCommand < Command$/;"	c	class:Byebug
+ThreadCommand	lib/byebug/commands/thread/current.rb	/^  class ThreadCommand < Command$/;"	c	class:Byebug
+ThreadCommand	lib/byebug/commands/thread/list.rb	/^  class ThreadCommand < Command$/;"	c	class:Byebug
+ThreadCommand	lib/byebug/commands/thread/resume.rb	/^  class ThreadCommand < Command$/;"	c	class:Byebug
+ThreadCommand	lib/byebug/commands/thread/stop.rb	/^  class ThreadCommand < Command$/;"	c	class:Byebug
+ThreadCommand	lib/byebug/commands/thread/switch.rb	/^  class ThreadCommand < Command$/;"	c	class:Byebug
+ThreadHelper	lib/byebug/helpers/thread.rb	/^    module ThreadHelper$/;"	m	class:Byebug.Helpers
+ThreadTest	test/commands/thread_test.rb	/^  class ThreadTest < TestCase$/;"	c	class:Byebug
+Thread_context	ext/byebug/byebug.c	/^Thread_context(VALUE self, VALUE thread)$/;"	f	file:	signature:(VALUE self, VALUE thread)
+Threading Support for Byebug	Ruby_Grant_2014_Report.md	/^# Threading Support for Byebug$/;"	h
+Threading support	GUIDE.md	/^### Threading support$/;"	h
+ToggleHelper	lib/byebug/helpers/toggle.rb	/^    module ToggleHelper$/;"	m	class:Byebug.Helpers
+TopLevelBlockEventsTest	test/commands/next_test.rb	/^  class TopLevelBlockEventsTest < TestCase$/;"	c
+TracevarCommand	lib/byebug/commands/tracevar.rb	/^  class TracevarCommand < Command$/;"	c	class:Byebug
+TracevarTest	test/commands/tracevar_test.rb	/^  class TracevarTest < TestCase$/;"	c	class:Byebug
+Tracing	ext/byebug/byebug.c	/^Tracing(VALUE self)$/;"	f	file:	signature:(VALUE self)
+TrailingWhitespaceLinter	tasks/linter.rb	/^class TrailingWhitespaceLinter$/;"	c
+UNUSED	ext/byebug/byebug.h	8;"	d
+UndisplayCommand	lib/byebug/commands/undisplay.rb	/^  class UndisplayCommand < Command$/;"	c	class:Byebug
+UndisplayTest	test/commands/undisplay_test.rb	/^  class UndisplayTest < TestCase$/;"	c	class:Byebug
+Unlock	ext/byebug/threads.c	/^Unlock(VALUE self)$/;"	f	file:	signature:(VALUE self)
+UntracevarCommand	lib/byebug/commands/untracevar.rb	/^  class UntracevarCommand < Command$/;"	c	class:Byebug
+UpCommand	lib/byebug/commands/up.rb	/^  class UpCommand < Command$/;"	c	class:Byebug
+UpTest	test/commands/up_test.rb	/^  class UpTest < TestCase$/;"	c	class:Byebug
+Usage	README.md	/^## Usage$/;"	h
+VERSION	lib/byebug/version.rb	/^  VERSION = "11.1.3"$/;"	c
+VERSIONS	docker/manager.rb	/^    VERSIONS = %w[$/;"	c
+VarCommand	lib/byebug/commands/var.rb	/^  class VarCommand < Command$/;"	c	class:Byebug
+VarCommand	lib/byebug/commands/var/all.rb	/^  class VarCommand < Command$/;"	c	class:Byebug
+VarCommand	lib/byebug/commands/var/args.rb	/^  class VarCommand < Command$/;"	c	class:Byebug
+VarCommand	lib/byebug/commands/var/const.rb	/^  class VarCommand < Command$/;"	c	class:Byebug
+VarCommand	lib/byebug/commands/var/global.rb	/^  class VarCommand < Command$/;"	c	class:Byebug
+VarCommand	lib/byebug/commands/var/instance.rb	/^  class VarCommand < Command$/;"	c	class:Byebug
+VarCommand	lib/byebug/commands/var/local.rb	/^  class VarCommand < Command$/;"	c	class:Byebug
+VarHelper	lib/byebug/helpers/var.rb	/^    module VarHelper$/;"	m	class:Byebug.Helpers
+VarTest	test/commands/var_test.rb	/^  class VarTest < TestCase$/;"	c	class:Byebug
+Verbose	ext/byebug/byebug.c	/^Verbose(VALUE self)$/;"	f	file:	signature:(VALUE self)
+WhereCommand	lib/byebug/commands/where.rb	/^  class WhereCommand < Command$/;"	c	class:Byebug
+WhereStandardTest	test/commands/where_test.rb	/^  class WhereStandardTest < TestCase$/;"	c	class:Byebug
+WhereWithDeeplyNestedPathsTest	test/commands/where_test.rb	/^  class WhereWithDeeplyNestedPathsTest < WhereStandardTest$/;"	c
+WhereWithNotDeeplyNestedPathsTest	test/commands/where_test.rb	/^    class WhereWithNotDeeplyNestedPathsTest < WhereStandardTest$/;"	c
+WidthSetting	lib/byebug/settings/width.rb	/^  class WidthSetting < Setting$/;"	c	class:Byebug
+[1.0.0] - 2013-03-29	CHANGELOG.md	/^## [1.0.0] - 2013-03-29$/;"	h
+[1.0.1] - 2013-04-06	CHANGELOG.md	/^## [1.0.1] - 2013-04-06$/;"	h
+[1.0.2] - 2013-04-09	CHANGELOG.md	/^## [1.0.2] - 2013-04-09$/;"	h
+[1.0.3] - 2013-04-23	CHANGELOG.md	/^## [1.0.3] - 2013-04-23$/;"	h
+[1.1.0] - 2013-04-30	CHANGELOG.md	/^## [1.1.0] - 2013-04-30$/;"	h
+[1.1.1] - 2013-05-07	CHANGELOG.md	/^## [1.1.1] - 2013-05-07$/;"	h
+[1.2.0] - 2013-05-20	CHANGELOG.md	/^## [1.2.0] - 2013-05-20$/;"	h
+[1.3.0] - 2013-05-25	CHANGELOG.md	/^## [1.3.0] - 2013-05-25$/;"	h
+[1.3.1] - 2013-06-02	CHANGELOG.md	/^## [1.3.1] - 2013-06-02$/;"	h
+[1.4.0] - 2013-06-05	CHANGELOG.md	/^## [1.4.0] - 2013-06-05$/;"	h
+[1.4.1] - 2013-06-15	CHANGELOG.md	/^## [1.4.1] - 2013-06-15$/;"	h
+[1.4.2] - 2013-06-20	CHANGELOG.md	/^## [1.4.2] - 2013-06-20$/;"	h
+[1.5.0] - 2013-06-21	CHANGELOG.md	/^## [1.5.0] - 2013-06-21$/;"	h
+[1.6.0] - 2013-07-10	CHANGELOG.md	/^## [1.6.0] - 2013-07-10$/;"	h
+[1.6.1] - 2013-07-10	CHANGELOG.md	/^## [1.6.1] - 2013-07-10$/;"	h
+[1.7.0] - 2013-08-03	CHANGELOG.md	/^## [1.7.0] - 2013-08-03$/;"	h
+[1.8.0] - 2013-08-12	CHANGELOG.md	/^## [1.8.0] - 2013-08-12$/;"	h
+[1.8.1] - 2013-08-12	CHANGELOG.md	/^## [1.8.1] - 2013-08-12$/;"	h
+[1.8.2] - 2013-08-16	CHANGELOG.md	/^## [1.8.2] - 2013-08-16$/;"	h
+[10.0.0] - 2018-01-26	CHANGELOG.md	/^## [10.0.0] - 2018-01-26$/;"	h
+[10.0.1] - 2018-03-21	CHANGELOG.md	/^## [10.0.1] - 2018-03-21$/;"	h
+[10.0.2] - 2018-03-30	CHANGELOG.md	/^## [10.0.2] - 2018-03-30$/;"	h
+[11.0.0] - 2019-02-15	CHANGELOG.md	/^## [11.0.0] - 2019-02-15$/;"	h
+[11.0.1] - 2019-03-18	CHANGELOG.md	/^## [11.0.1] - 2019-03-18$/;"	h
+[11.1.0] - 2020-01-20	CHANGELOG.md	/^## [11.1.0] - 2020-01-20$/;"	h
+[11.1.1] - 2020-01-24	CHANGELOG.md	/^## [11.1.1] - 2020-01-24$/;"	h
+[11.1.2] - 2020-04-17	CHANGELOG.md	/^## [11.1.2] - 2020-04-17$/;"	h
+[11.1.3] - 2020-04-23	CHANGELOG.md	/^## [11.1.3] - 2020-04-23$/;"	h
+[2.0.0] - 2013-08-30	CHANGELOG.md	/^## [2.0.0] - 2013-08-30$/;"	h
+[2.1.0] - 2013-09-08	CHANGELOG.md	/^## [2.1.0] - 2013-09-08$/;"	h
+[2.1.1] - 2013-09-10	CHANGELOG.md	/^## [2.1.1] - 2013-09-10$/;"	h
+[2.2.0] - 2013-09-22	CHANGELOG.md	/^## [2.2.0] - 2013-09-22$/;"	h
+[2.2.1] - 2013-09-24	CHANGELOG.md	/^## [2.2.1] - 2013-09-24$/;"	h
+[2.2.2] - 2013-09-25	CHANGELOG.md	/^## [2.2.2] - 2013-09-25$/;"	h
+[2.3.0] - 2013-10-09	CHANGELOG.md	/^## [2.3.0] - 2013-10-09$/;"	h
+[2.3.1] - 2013-10-17	CHANGELOG.md	/^## [2.3.1] - 2013-10-17$/;"	h
+[2.4.0] - 2013-12-02	CHANGELOG.md	/^## [2.4.0] - 2013-12-02$/;"	h
+[2.4.1] - 2013-12-05	CHANGELOG.md	/^## [2.4.1] - 2013-12-05$/;"	h
+[2.5.0] - 2013-12-14	CHANGELOG.md	/^## [2.5.0] - 2013-12-14$/;"	h
+[2.6.0] - 2014-02-08	CHANGELOG.md	/^## [2.6.0] - 2014-02-08$/;"	h
+[2.7.0] - 2014-02-24	CHANGELOG.md	/^## [2.7.0] - 2014-02-24$/;"	h
+[3.0.0] - 2014-04-17	CHANGELOG.md	/^## [3.0.0] - 2014-04-17$/;"	h
+[3.1.0] - 2014-04-23	CHANGELOG.md	/^## [3.1.0] - 2014-04-23$/;"	h
+[3.1.1] - 2014-04-23	CHANGELOG.md	/^## [3.1.1] - 2014-04-23$/;"	h
+[3.1.2] - 2014-04-23	CHANGELOG.md	/^## [3.1.2] - 2014-04-23$/;"	h
+[3.2.0] - 2014-08-02	CHANGELOG.md	/^## [3.2.0] - 2014-08-02$/;"	h
+[3.3.0] - 2014-08-28	CHANGELOG.md	/^## [3.3.0] - 2014-08-28$/;"	h
+[3.4.0] - 2014-09-01	CHANGELOG.md	/^## [3.4.0] - 2014-09-01$/;"	h
+[3.4.1] - 2014-09-25	CHANGELOG.md	/^## [3.4.1] - 2014-09-25$/;"	h
+[3.4.2] - 2014-09-26	CHANGELOG.md	/^## [3.4.2] - 2014-09-26$/;"	h
+[3.5.0] - 2014-09-28	CHANGELOG.md	/^## [3.5.0] - 2014-09-28$/;"	h
+[3.5.1] - 2014-09-29	CHANGELOG.md	/^## [3.5.1] - 2014-09-29$/;"	h
+[4.0.0] - 2015-03-13	CHANGELOG.md	/^## [4.0.0] - 2015-03-13$/;"	h
+[4.0.1] - 2015-03-13	CHANGELOG.md	/^## [4.0.1] - 2015-03-13$/;"	h
+[4.0.2] - 2015-03-16	CHANGELOG.md	/^## [4.0.2] - 2015-03-16$/;"	h
+[4.0.3] - 2015-03-19	CHANGELOG.md	/^## [4.0.3] - 2015-03-19$/;"	h
+[4.0.4] - 2015-03-27	CHANGELOG.md	/^## [4.0.4] - 2015-03-27$/;"	h
+[4.0.5] - 2015-04-02	CHANGELOG.md	/^## [4.0.5] - 2015-04-02$/;"	h
+[5.0.0] - 2015-05-18	CHANGELOG.md	/^## [5.0.0] - 2015-05-18$/;"	h
+[6.0.0] - 2015-08-17	CHANGELOG.md	/^## [6.0.0] - 2015-08-17$/;"	h
+[6.0.1] - 2015-08-19	CHANGELOG.md	/^## [6.0.1] - 2015-08-19$/;"	h
+[6.0.2] - 2015-08-20	CHANGELOG.md	/^## [6.0.2] - 2015-08-20$/;"	h
+[7.0.0] - 2015-11-04	CHANGELOG.md	/^## [7.0.0] - 2015-11-04$/;"	h
+[8.0.0] - 2015-11-05	CHANGELOG.md	/^## [8.0.0] - 2015-11-05$/;"	h
+[8.0.1] - 2015-11-07	CHANGELOG.md	/^## [8.0.1] - 2015-11-07$/;"	h
+[8.1.0] - 2015-11-09	CHANGELOG.md	/^## [8.1.0] - 2015-11-09$/;"	h
+[8.2.0] - 2015-11-12	CHANGELOG.md	/^## [8.2.0] - 2015-11-12$/;"	h
+[8.2.1] - 2015-11-26	CHANGELOG.md	/^## [8.2.1] - 2015-11-26$/;"	h
+[8.2.2] - 2016-02-01	CHANGELOG.md	/^## [8.2.2] - 2016-02-01$/;"	h
+[8.2.3] - 2016-04-07	CHANGELOG.md	/^## [8.2.3] - 2016-04-07$/;"	h
+[8.2.4] - 2016-04-08	CHANGELOG.md	/^## [8.2.4] - 2016-04-08$/;"	h
+[8.2.5] - 2016-04-27	CHANGELOG.md	/^## [8.2.5] - 2016-04-27$/;"	h
+[9.0.0] - 2016-05-11	CHANGELOG.md	/^## [9.0.0] - 2016-05-11$/;"	h
+[9.0.1] - 2016-05-14	CHANGELOG.md	/^## [9.0.1] - 2016-05-14$/;"	h
+[9.0.2] - 2016-05-15	CHANGELOG.md	/^## [9.0.2] - 2016-05-15$/;"	h
+[9.0.3] - 2016-05-16	CHANGELOG.md	/^## [9.0.3] - 2016-05-16$/;"	h
+[9.0.4] - 2016-05-19	CHANGELOG.md	/^## [9.0.4] - 2016-05-19$/;"	h
+[9.0.5] - 2016-05-28	CHANGELOG.md	/^## [9.0.5] - 2016-05-28$/;"	h
+[9.0.6] - 2016-09-29	CHANGELOG.md	/^## [9.0.6] - 2016-09-29$/;"	h
+[9.1.0] - 2017-08-22	CHANGELOG.md	/^## [9.1.0] - 2017-08-22$/;"	h
+[Unreleased]	CHANGELOG.md	/^## [Unreleased]$/;"	h
+[]	lib/byebug/setting.rb	/^      def [](name)$/;"	f	class:Byebug.Setting
+[]=	lib/byebug/setting.rb	/^      def []=(name, value)$/;"	f	class:Byebug.Setting
+__anon2::backtrace	ext/byebug/byebug.h	/^  VALUE backtrace; \/* [[loc, self, klass, binding], ...] *\/$/;"	m	struct:__anon2	access:public
+__anon2::calced_stack_size	ext/byebug/byebug.h	/^  int calced_stack_size;$/;"	m	struct:__anon2	access:public
+__anon2::dest_frame	ext/byebug/byebug.h	/^  int dest_frame; \/* next stop's frame if stopped by next     *\/$/;"	m	struct:__anon2	access:public
+__anon2::flags	ext/byebug/byebug.h	/^  int flags;$/;"	m	struct:__anon2	access:public
+__anon2::lines	ext/byebug/byebug.h	/^  int lines;      \/* # of lines in dest_frame before stopping *\/$/;"	m	struct:__anon2	access:public
+__anon2::steps	ext/byebug/byebug.h	/^  int steps;      \/* # of steps before stopping               *\/$/;"	m	struct:__anon2	access:public
+__anon2::steps_out	ext/byebug/byebug.h	/^  int steps_out;  \/* # of returns before stopping             *\/$/;"	m	struct:__anon2	access:public
+__anon2::stop_reason	ext/byebug/byebug.h	/^  ctx_stop_reason stop_reason;$/;"	m	struct:__anon2	access:public
+__anon2::thnum	ext/byebug/byebug.h	/^  int thnum;$/;"	m	struct:__anon2	access:public
+__anon2::thread	ext/byebug/byebug.h	/^  VALUE thread;$/;"	m	struct:__anon2	access:public
+__anon4::tbl	ext/byebug/byebug.h	/^  st_table *tbl;$/;"	m	struct:__anon4	access:public
+__anon5::__anon6::line	ext/byebug/byebug.h	/^    int line;$/;"	m	union:__anon5::__anon6	access:public
+__anon5::__anon6::mid	ext/byebug/byebug.h	/^    ID mid;$/;"	m	union:__anon5::__anon6	access:public
+__anon5::enabled	ext/byebug/byebug.h	/^  VALUE enabled;$/;"	m	struct:__anon5	access:public
+__anon5::expr	ext/byebug/byebug.h	/^  VALUE expr;$/;"	m	struct:__anon5	access:public
+__anon5::hit_condition	ext/byebug/byebug.h	/^  enum hit_condition hit_condition;$/;"	m	struct:__anon5	typeref:enum:__anon5::hit_condition	access:public
+__anon5::hit_count	ext/byebug/byebug.h	/^  int hit_count;$/;"	m	struct:__anon5	access:public
+__anon5::hit_value	ext/byebug/byebug.h	/^  int hit_value;$/;"	m	struct:__anon5	access:public
+__anon5::id	ext/byebug/byebug.h	/^  int id;$/;"	m	struct:__anon5	access:public
+__anon5::pos	ext/byebug/byebug.h	/^  } pos;$/;"	m	struct:__anon5	typeref:union:__anon5::__anon6	access:public
+__anon5::source	ext/byebug/byebug.h	/^  VALUE source;$/;"	m	struct:__anon5	access:public
+__anon5::type	ext/byebug/byebug.h	/^  enum bp_type type;$/;"	m	struct:__anon5	typeref:enum:__anon5::bp_type	access:public
+_binding	lib/byebug/frame.rb	/^    def _binding$/;"	f	class:Byebug.Frame
+_class	lib/byebug/frame.rb	/^    def _class$/;"	f	class:Byebug.Frame
+_method	lib/byebug/frame.rb	/^    def _method$/;"	f	class:Byebug.Frame
+_self	lib/byebug/frame.rb	/^    def _self$/;"	f	class:Byebug.Frame
+abi_version	docker/manager.rb	/^    def abi_version$/;"	f	class:Docker
+acquire_lock	ext/byebug/byebug.h	/^extern void acquire_lock(debug_context_t *dc);$/;"	p	signature:(debug_context_t *dc)
+acquire_lock	ext/byebug/threads.c	/^acquire_lock(debug_context_t *dc)$/;"	f	signature:(debug_context_t *dc)
+activate_bundler	bin/bundle	/^  def activate_bundler(bundler_version)$/;"	f
+actual_control_port	lib/byebug/remote.rb	/^    def actual_control_port$/;"	f	class:Byebug
+actual_port	lib/byebug/remote.rb	/^    def actual_port$/;"	f	class:Byebug
+add	lib/byebug/breakpoint.rb	/^    def self.add(file, line, expr = nil)$/;"	F	class:Byebug.Breakpoint
+add	lib/byebug/commands/catch.rb	/^    def add(exception)$/;"	f	class:Byebug.CatchCommand
+add_line_breakpoint	lib/byebug/commands/break.rb	/^    def add_line_breakpoint(file, line)$/;"	f	class:Byebug.BreakCommand
+adjust_frame	lib/byebug/helpers/frame.rb	/^      def adjust_frame(new_frame)$/;"	f	class:Byebug.Helpers.FrameHelper
+after_repl	lib/byebug/processors/command_processor.rb	/^    def after_repl$/;"	f	class:Byebug.CommandProcessor
+after_repl	lib/byebug/processors/script_processor.rb	/^    def after_repl$/;"	f	class:Byebug.ScriptProcessor
+all.rb	lib/byebug/commands/var/all.rb	1;"	F
+all_files	lib/byebug/helpers/path.rb	/^      def all_files$/;"	f	class:Byebug.Helpers.PathHelper
+all_test_suites	test/minitest_runner.rb	/^    def all_test_suites$/;"	f	class:Byebug.filter_runnables
+allowing_other_threads	lib/byebug/helpers/eval.rb	/^      def allowing_other_threads$/;"	f	class:Byebug.Helpers.EvalHelper
+always_run	lib/byebug/command.rb	/^      def always_run$/;"	f	class:Byebug.Command
+amend	lib/byebug/source_file_formatter.rb	/^    def amend(line, ceiling)$/;"	f	class:Byebug.SourceFileFormatter
+amend_final	lib/byebug/source_file_formatter.rb	/^    def amend_final(line)$/;"	f	class:Byebug.SourceFileFormatter
+amend_initial	lib/byebug/source_file_formatter.rb	/^    def amend_initial(line)$/;"	f	class:Byebug.SourceFileFormatter
+applicable_files	tasks/linter.rb	/^  def applicable_files$/;"	f	class:CLangFormatLinter
+applicable_files	tasks/linter.rb	/^  def applicable_files$/;"	f	class:ExecutableLinter
+applicable_files	tasks/linter.rb	/^  def applicable_files$/;"	f	class:TabLinter
+applicable_files	tasks/linter.rb	/^  def applicable_files$/;"	f	class:TrailingWhitespaceLinter
+argc	ext/byebug/byebug.h	/^  int argc;$/;"	m	struct:call_with_inspection_data	access:public
+args	lib/byebug/frame.rb	/^    def args$/;"	f	class:Byebug.Frame
+args.rb	lib/byebug/commands/var/args.rb	1;"	F
+arguments	lib/byebug/command.rb	/^    def arguments$/;"	f	class:Byebug.Command
+argv	ext/byebug/byebug.h	/^  VALUE *argv;$/;"	m	struct:call_with_inspection_data	access:public
+array_of_args	lib/byebug/printers/base.rb	/^      def array_of_args(collection, &_block)$/;"	f	class:Byebug.Printers
+assert_calls	test/support/assertions.rb	/^    def assert_calls(object, method, *expected_args, &block)$/;"	f	class:Minitest.Assertions
+assert_includes_in_order	test/support/assertions.rb	/^    def assert_includes_in_order(given, original, msg = nil)$/;"	f	class:Minitest.Assertions
+assert_location	test/support/assertions.rb	/^    def assert_location(file, line)$/;"	f	class:Minitest.Assertions
+assert_match_error	test/runner_without_target_program_test.rb	/^    def assert_match_error(message, output)$/;"	f	class:Byebug.RunnerWithoutTargetProgramTest
+assert_program_finished	test/support/assertions.rb	/^    def assert_program_finished$/;"	f	class:Minitest.Assertions
+assert_restarts	test/commands/restart_test.rb	/^    def assert_restarts(arg, expected_cmd_line)$/;"	f
+assertions.rb	test/support/assertions.rb	1;"	F
+at_breakpoint	lib/byebug/context.rb	/^    def at_breakpoint(breakpoint)$/;"	f	class:Byebug
+at_breakpoint	lib/byebug/processors/command_processor.rb	/^    def at_breakpoint(brkpt)$/;"	f	class:Byebug.CommandProcessor
+at_catchpoint	lib/byebug/context.rb	/^    def at_catchpoint(exception)$/;"	f	class:Byebug
+at_catchpoint	lib/byebug/processors/command_processor.rb	/^    def at_catchpoint(exception)$/;"	f	class:Byebug.CommandProcessor
+at_end	lib/byebug/context.rb	/^    def at_end$/;"	f	class:Byebug
+at_end	lib/byebug/processors/command_processor.rb	/^    def at_end$/;"	f	class:Byebug.CommandProcessor
+at_line	lib/byebug/context.rb	/^    def at_line$/;"	f	class:Byebug
+at_line	lib/byebug/processors/command_processor.rb	/^    def at_line$/;"	f	class:Byebug.CommandProcessor
+at_return	lib/byebug/context.rb	/^    def at_return(return_value)$/;"	f	class:Byebug
+at_return	lib/byebug/processors/command_processor.rb	/^    def at_return(return_value)$/;"	f	class:Byebug.CommandProcessor
+at_tracing	lib/byebug/context.rb	/^    def at_tracing$/;"	f	class:Byebug
+at_tracing	lib/byebug/processors/command_processor.rb	/^    def at_tracing$/;"	f	class:Byebug.CommandProcessor
+attach	lib/byebug/attacher.rb	/^  def self.attach$/;"	F	class:Byebug
+attacher.rb	lib/byebug/attacher.rb	1;"	F
+auto_cmds_for	lib/byebug/processors/command_processor.rb	/^    def auto_cmds_for(run_level)$/;"	f	class:Byebug
+auto_range	lib/byebug/commands/list.rb	/^    def auto_range(direction)$/;"	f	class:Byebug.ListCommand
+auto_run	lib/byebug/commands/skip.rb	/^    def auto_run$/;"	f	class:Byebug
+autoirb.rb	lib/byebug/settings/autoirb.rb	1;"	F
+autolist.rb	lib/byebug/settings/autolist.rb	1;"	F
+autopry.rb	lib/byebug/settings/autopry.rb	1;"	F
+autorestore	lib/byebug/interface.rb	/^    def autorestore$/;"	f	class:Byebug.Interface
+autosave	lib/byebug/interface.rb	/^    def autosave$/;"	f	class:Byebug.Interface
+autosave.rb	lib/byebug/settings/autosave.rb	1;"	F
+backtrace	ext/byebug/byebug.h	/^  VALUE backtrace; \/* [[loc, self, klass, binding], ...] *\/$/;"	m	struct:__anon2	access:public
+banner	lib/byebug/runner.rb	/^    def banner$/;"	f	class:Byebug.Runner
+banner	lib/byebug/settings/autoirb.rb	/^    def banner$/;"	f	class:Byebug.AutoirbSetting
+banner	lib/byebug/settings/autolist.rb	/^    def banner$/;"	f	class:Byebug.AutolistSetting
+banner	lib/byebug/settings/autopry.rb	/^    def banner$/;"	f	class:Byebug.AutoprySetting
+banner	lib/byebug/settings/autosave.rb	/^    def banner$/;"	f	class:Byebug.AutosaveSetting
+banner	lib/byebug/settings/basename.rb	/^    def banner$/;"	f	class:Byebug.BasenameSetting
+banner	lib/byebug/settings/callstyle.rb	/^    def banner$/;"	f	class:Byebug.CallstyleSetting
+banner	lib/byebug/settings/fullpath.rb	/^    def banner$/;"	f	class:Byebug.FullpathSetting
+banner	lib/byebug/settings/histfile.rb	/^    def banner$/;"	f	class:Byebug.HistfileSetting
+banner	lib/byebug/settings/histsize.rb	/^    def banner$/;"	f	class:Byebug.HistsizeSetting
+banner	lib/byebug/settings/linetrace.rb	/^    def banner$/;"	f	class:Byebug.LinetraceSetting
+banner	lib/byebug/settings/listsize.rb	/^    def banner$/;"	f	class:Byebug.ListsizeSetting
+banner	lib/byebug/settings/post_mortem.rb	/^    def banner$/;"	f	class:Byebug.PostMortemSetting
+banner	lib/byebug/settings/savefile.rb	/^    def banner$/;"	f	class:Byebug.SavefileSetting
+banner	lib/byebug/settings/stack_on_error.rb	/^    def banner$/;"	f	class:Byebug.StackOnErrorSetting
+banner	lib/byebug/settings/width.rb	/^    def banner$/;"	f	class:Byebug.WidthSetting
+base.rb	lib/byebug/printers/base.rb	1;"	F
+basename.rb	lib/byebug/settings/basename.rb	1;"	F
+before_repl	lib/byebug/processors/command_processor.rb	/^    def before_repl$/;"	f	class:Byebug.CommandProcessor
+before_suite	test/support/test_case.rb	/^    def self.before_suite$/;"	F	class:Byebug.TestCase
+bin.rb	lib/byebug/helpers/bin.rb	1;"	F
+bin_file	lib/byebug/helpers/path.rb	/^      def bin_file$/;"	f	class:Byebug.Helpers.PathHelper
+bin_helper_test.rb	test/helpers/bin_helper_test.rb	1;"	F
+binstub	test/minitest_runner_test.rb	/^    def binstub$/;"	f	class:Byebug.MinitestRunnerTest
+binstub	test/support/utils.rb	/^    def binstub$/;"	f	class:Byebug.TestUtils
+boolean?	lib/byebug/setting.rb	/^    def boolean?$/;"	f	class:Byebug.Setting
+bp_type	ext/byebug/byebug.h	/^enum bp_type$/;"	g
+break.rb	lib/byebug/commands/break.rb	1;"	F
+break_test.rb	test/commands/break_test.rb	1;"	F
+breakpoint.c	ext/byebug/breakpoint.c	1;"	F
+breakpoint.rb	lib/byebug/breakpoint.rb	1;"	F
+breakpoint_max	ext/byebug/breakpoint.c	/^static int breakpoint_max;$/;"	v	file:
+breakpoint_t	ext/byebug/byebug.h	/^} breakpoint_t;$/;"	t	typeref:struct:__anon5
+breakpoints	ext/byebug/byebug.c	/^static VALUE breakpoints = Qnil;$/;"	v	file:
+breakpoints.rb	lib/byebug/commands/disable/breakpoints.rb	1;"	F
+breakpoints.rb	lib/byebug/commands/enable/breakpoints.rb	1;"	F
+breakpoints.rb	lib/byebug/commands/info/breakpoints.rb	1;"	F
+brkpt_create	ext/byebug/breakpoint.c	/^brkpt_create(VALUE klass)$/;"	f	file:	signature:(VALUE klass)
+brkpt_enabled	ext/byebug/breakpoint.c	/^brkpt_enabled(VALUE self)$/;"	f	file:	signature:(VALUE self)
+brkpt_expr	ext/byebug/breakpoint.c	/^brkpt_expr(VALUE self)$/;"	f	file:	signature:(VALUE self)
+brkpt_hit_condition	ext/byebug/breakpoint.c	/^brkpt_hit_condition(VALUE self)$/;"	f	file:	signature:(VALUE self)
+brkpt_hit_count	ext/byebug/breakpoint.c	/^brkpt_hit_count(VALUE self)$/;"	f	file:	signature:(VALUE self)
+brkpt_hit_value	ext/byebug/breakpoint.c	/^brkpt_hit_value(VALUE self)$/;"	f	file:	signature:(VALUE self)
+brkpt_id	ext/byebug/breakpoint.c	/^brkpt_id(VALUE self)$/;"	f	file:	signature:(VALUE self)
+brkpt_initialize	ext/byebug/breakpoint.c	/^brkpt_initialize(VALUE self, VALUE source, VALUE pos, VALUE expr)$/;"	f	file:	signature:(VALUE self, VALUE source, VALUE pos, VALUE expr)
+brkpt_pos	ext/byebug/breakpoint.c	/^brkpt_pos(VALUE self)$/;"	f	file:	signature:(VALUE self)
+brkpt_set_enabled	ext/byebug/breakpoint.c	/^brkpt_set_enabled(VALUE self, VALUE enabled)$/;"	f	file:	signature:(VALUE self, VALUE enabled)
+brkpt_set_expr	ext/byebug/breakpoint.c	/^brkpt_set_expr(VALUE self, VALUE expr)$/;"	f	file:	signature:(VALUE self, VALUE expr)
+brkpt_set_hit_condition	ext/byebug/breakpoint.c	/^brkpt_set_hit_condition(VALUE self, VALUE value)$/;"	f	file:	signature:(VALUE self, VALUE value)
+brkpt_set_hit_value	ext/byebug/breakpoint.c	/^brkpt_set_hit_value(VALUE self, VALUE value)$/;"	f	file:	signature:(VALUE self, VALUE value)
+brkpt_source	ext/byebug/breakpoint.c	/^brkpt_source(VALUE self)$/;"	f	file:	signature:(VALUE self)
+buffer	lib/byebug/history.rb	/^    def buffer$/;"	f	class:Byebug.History
+build	docker/manager.rb	/^    def build$/;"	f	class:Docker.Manager
+build_all	docker/manager.rb	/^      def build_all$/;"	f	class:Docker.Manager
+build_cmd	lib/byebug/errors.rb	/^    def build_cmd(*args)$/;"	f	class:Byebug.CommandNotFound
+build_default	docker/manager.rb	/^      def build_default$/;"	f	class:Docker.Manager
+bundle	bin/bundle	1;"	F
+bundler_version	bin/bundle	/^  def bundler_version$/;"	f
+byebug	exe/byebug	1;"	F
+byebug	lib/byebug/attacher.rb	/^  def byebug$/;"	f	class:Kernel
+byebug.c	ext/byebug/byebug.c	1;"	F
+byebug.h	ext/byebug/byebug.h	1;"	F
+byebug.rb	lib/byebug.rb	1;"	F
+byebug_add_to_locked	ext/byebug/byebug.h	/^extern void byebug_add_to_locked(VALUE thread);$/;"	p	signature:(VALUE thread)
+byebug_add_to_locked	ext/byebug/locker.c	/^byebug_add_to_locked(VALUE thread)$/;"	f	signature:(VALUE thread)
+byebug_bin	test/commands/restart_test.rb	/^    def byebug_bin$/;"	f
+byebug_context_create	ext/byebug/byebug.h	/^extern VALUE byebug_context_create(VALUE thread);$/;"	p	signature:(VALUE thread)
+byebug_context_create	ext/byebug/context.c	/^byebug_context_create(VALUE thread)$/;"	f	signature:(VALUE thread)
+byebug_pop_from_locked	ext/byebug/byebug.h	/^extern VALUE byebug_pop_from_locked();$/;"	p	signature:()
+byebug_pop_from_locked	ext/byebug/locker.c	/^byebug_pop_from_locked()$/;"	f
+byebug_remove_from_locked	ext/byebug/byebug.h	/^extern void byebug_remove_from_locked(VALUE thread);$/;"	p	signature:(VALUE thread)
+byebug_remove_from_locked	ext/byebug/locker.c	/^byebug_remove_from_locked(VALUE thread)$/;"	f	signature:(VALUE thread)
+byebug_reset_stepping_stop_points	ext/byebug/byebug.h	/^extern void byebug_reset_stepping_stop_points(debug_context_t *context);$/;"	p	signature:(debug_context_t *context)
+byebug_reset_stepping_stop_points	ext/byebug/context.c	/^byebug_reset_stepping_stop_points(debug_context_t *context)$/;"	f	signature:(debug_context_t *context)
+cBreakpoint	ext/byebug/breakpoint.c	/^static VALUE cBreakpoint;$/;"	v	file:
+cContext	ext/byebug/context.c	/^static VALUE cContext;$/;"	v	file:
+cDebugThread	ext/byebug/context.c	/^static VALUE cDebugThread;$/;"	v	file:
+cThreadsTable	ext/byebug/threads.c	/^static VALUE cThreadsTable;$/;"	v	file:
+c_args	lib/byebug/frame.rb	/^    def c_args$/;"	f	class:Byebug.Frame
+c_frame?	lib/byebug/frame.rb	/^    def c_frame?$/;"	f	class:Byebug.Frame
+calc	test/processors/command_processor_test.rb	/^            def calc(number)$/;"	f	class:ProcessorEvaluationAndThreadsTest.program.Byebug
+calced_stack_size	ext/byebug/byebug.h	/^  int calced_stack_size;$/;"	m	struct:__anon2	access:public
+call_at	ext/byebug/byebug.c	/^call_at(VALUE ctx, debug_context_t *dc, ID mid, int argc, VALUE arg)$/;"	f	file:	signature:(VALUE ctx, debug_context_t *dc, ID mid, int argc, VALUE arg)
+call_at_breakpoint	ext/byebug/byebug.c	/^call_at_breakpoint(VALUE ctx, debug_context_t *dc, VALUE breakpoint)$/;"	f	file:	signature:(VALUE ctx, debug_context_t *dc, VALUE breakpoint)
+call_at_catchpoint	ext/byebug/byebug.c	/^call_at_catchpoint(VALUE ctx, debug_context_t *dc, VALUE exp)$/;"	f	file:	signature:(VALUE ctx, debug_context_t *dc, VALUE exp)
+call_at_end	ext/byebug/byebug.c	/^call_at_end(VALUE ctx, debug_context_t *dc)$/;"	f	file:	signature:(VALUE ctx, debug_context_t *dc)
+call_at_line	ext/byebug/byebug.c	/^call_at_line(VALUE ctx, debug_context_t *dc)$/;"	f	file:	signature:(VALUE ctx, debug_context_t *dc)
+call_at_line_check	ext/byebug/byebug.c	/^call_at_line_check(VALUE ctx, debug_context_t *dc, VALUE breakpoint)$/;"	f	file:	signature:(VALUE ctx, debug_context_t *dc, VALUE breakpoint)
+call_at_return	ext/byebug/byebug.c	/^call_at_return(VALUE ctx, debug_context_t *dc, VALUE return_value)$/;"	f	file:	signature:(VALUE ctx, debug_context_t *dc, VALUE return_value)
+call_at_tracing	ext/byebug/byebug.c	/^call_at_tracing(VALUE ctx, debug_context_t *dc)$/;"	f	file:	signature:(VALUE ctx, debug_context_t *dc)
+call_event	ext/byebug/byebug.c	/^call_event(VALUE trace_point, void *data)$/;"	f	file:	signature:(VALUE trace_point, void *data)
+call_with_debug_inspector	ext/byebug/byebug.h	/^extern VALUE call_with_debug_inspector(struct call_with_inspection_data *data);$/;"	p	signature:(struct call_with_inspection_data *data)
+call_with_debug_inspector	ext/byebug/context.c	/^call_with_debug_inspector(struct call_with_inspection_data *data)$/;"	f	signature:(struct call_with_inspection_data *data)
+call_with_inspection_data	ext/byebug/byebug.h	/^struct call_with_inspection_data$/;"	s
+call_with_inspection_data::argc	ext/byebug/byebug.h	/^  int argc;$/;"	m	struct:call_with_inspection_data	access:public
+call_with_inspection_data::argv	ext/byebug/byebug.h	/^  VALUE *argv;$/;"	m	struct:call_with_inspection_data	access:public
+call_with_inspection_data::ctx	ext/byebug/byebug.h	/^  VALUE ctx;$/;"	m	struct:call_with_inspection_data	access:public
+call_with_inspection_data::dc	ext/byebug/byebug.h	/^  debug_context_t *dc;$/;"	m	struct:call_with_inspection_data	access:public
+call_with_inspection_data::id	ext/byebug/byebug.h	/^  ID id;$/;"	m	struct:call_with_inspection_data	access:public
+callstyle.rb	lib/byebug/settings/callstyle.rb	1;"	F
+camelize	lib/byebug/helpers/string.rb	/^      def camelize(str)$/;"	f	class:Byebug.Helpers.StringHelper
+camelized_path	test/support/test_case.rb	/^    def camelized_path$/;"	f	class:Byebug.TestCase
+catch.rb	lib/byebug/commands/catch.rb	1;"	F
+catch_test.rb	test/commands/catch_test.rb	1;"	F
+catchpoints	ext/byebug/byebug.c	/^static VALUE catchpoints = Qnil;$/;"	v	file:
+change_line	test/support/utils.rb	/^    def change_line(file, lineno, new_line)$/;"	f	class:Byebug.TestUtils
+changelog	test/changelog_test.rb	/^    def changelog$/;"	f	class:Byebug.ChangelogTest
+changelog_test.rb	test/changelog_test.rb	1;"	F
+check_breakpoint_by_expr	ext/byebug/breakpoint.c	/^check_breakpoint_by_expr(VALUE rb_breakpoint, VALUE bind)$/;"	f	file:	signature:(VALUE rb_breakpoint, VALUE bind)
+check_breakpoint_by_hit_condition	ext/byebug/breakpoint.c	/^check_breakpoint_by_hit_condition(VALUE rb_breakpoint)$/;"	f	file:	signature:(VALUE rb_breakpoint)
+check_breakpoint_by_method	ext/byebug/breakpoint.c	/^check_breakpoint_by_method(VALUE rb_breakpoint, VALUE klass, ID mid, VALUE self)$/;"	f	file:	signature:(VALUE rb_breakpoint, VALUE klass, ID mid, VALUE self)
+check_breakpoint_by_pos	ext/byebug/breakpoint.c	/^check_breakpoint_by_pos(VALUE rb_breakpoint, char *file, int line)$/;"	f	file:	signature:(VALUE rb_breakpoint, char *file, int line)
+check_calls	test/support/assertions.rb	/^    def check_calls(check_method, object, method, *expected_args)$/;"	f	class:Minitest.Assertions
+check_error_doesnt_include	test/support/matchers.rb	/^    def check_error_doesnt_include(*args)$/;"	f	class:Byebug.TestMatchers
+check_error_includes	test/support/matchers.rb	/^    def check_error_includes(*args)$/;"	f	class:Byebug.TestMatchers
+check_output_doesnt_include	test/support/matchers.rb	/^    def check_output_doesnt_include(*args)$/;"	f	class:Byebug.TestMatchers
+check_output_includes	test/support/matchers.rb	/^    def check_output_includes(*args)$/;"	f	class:Byebug.TestMatchers
+check_started	ext/byebug/byebug.c	/^check_started()$/;"	f	file:
+check_stream	test/support/matchers.rb	/^    def check_stream(check_method, stream, *args)$/;"	f	class:Byebug.TestMatchers
+check_thread_i	ext/byebug/threads.c	/^check_thread_i(st_data_t key, st_data_t value, st_data_t data)$/;"	f	file:	signature:(st_data_t key, st_data_t value, st_data_t data)
+clang_format	tasks/linter.rb	/^  def clang_format$/;"	f	class:CLangFormatLinter
+classname_cmp	ext/byebug/breakpoint.c	/^classname_cmp(VALUE name, VALUE klass)$/;"	f	file:	signature:(VALUE name, VALUE klass)
+clean?	tasks/linter.rb	/^  def clean?(file)$/;"	f	class:CLangFormatLinter
+clean?	tasks/linter.rb	/^  def clean?(file)$/;"	f	class:ExecutableLinter
+clean?	tasks/linter.rb	/^  def clean?(file)$/;"	f	class:TabLinter
+clean?	tasks/linter.rb	/^  def clean?(file)$/;"	f	class:TrailingWhitespaceLinter
+cleanup	ext/byebug/byebug.c	/^cleanup(debug_context_t *dc)$/;"	f	file:	signature:(debug_context_t *dc)
+cleanup	test/commands/save_test.rb	/^    def cleanup(file)$/;"	f	class:Byebug
+cleanup_dead_threads	ext/byebug/threads.c	/^cleanup_dead_threads(void)$/;"	f	file:	signature:(void)
+cleanup_namespace	test/support/test_case.rb	/^    def cleanup_namespace$/;"	f	class:Byebug.TestCase
+clear	lib/byebug/commands/catch.rb	/^    def clear$/;"	f	class:Byebug.CatchCommand
+clear	lib/byebug/history.rb	/^    def clear$/;"	f	class:Byebug
+clear	lib/byebug/interfaces/test_interface.rb	/^    def clear$/;"	f	class:Byebug.TestInterface
+clear_displays	test/support/utils.rb	/^    def clear_displays$/;"	f	class:Byebug.TestUtils
+clear_example_file	test/support/test_case.rb	/^    def clear_example_file$/;"	f	class:Byebug.TestCase
+clear_tracepoints	ext/byebug/byebug.c	/^clear_tracepoints(VALUE self)$/;"	f	file:	signature:(VALUE self)
+client	lib/byebug/remote.rb	/^    def client$/;"	f	class:Byebug
+client	test/support/remote_debugging_tests.rb	/^    def client$/;"	f	class:Byebug
+client.rb	lib/byebug/remote/client.rb	1;"	F
+close	lib/byebug/interface.rb	/^    def close$/;"	f	class:Byebug.Interface
+close	lib/byebug/interfaces/remote_interface.rb	/^    def close$/;"	f	class:Byebug.RemoteInterface
+close	lib/byebug/interfaces/script_interface.rb	/^    def close$/;"	f	class:Byebug.ScriptInterface
+close_debug_inspector	ext/byebug/context.c	/^close_debug_inspector(struct call_with_inspection_data *cwi)$/;"	f	file:	signature:(struct call_with_inspection_data *cwi)
+close_debug_inspector_ensure	ext/byebug/context.c	/^close_debug_inspector_ensure(VALUE v)$/;"	f	file:	signature:(VALUE v)
+cmd_after_replace	test/support/utils.rb	/^    def cmd_after_replace(file, lineno, content, cmd)$/;"	f	class:Byebug.TestUtils
+code_of_conduct.md	code_of_conduct.md	1;"	F
+columnize	lib/byebug/command.rb	/^      def columnize(width)$/;"	f	class:Byebug.Command
+command	lib/byebug/commands/help.rb	/^    def command$/;"	f	class:Byebug.HelpCommand
+command.rb	lib/byebug/command.rb	1;"	F
+command_list	lib/byebug/processors/command_processor.rb	/^    def command_list$/;"	f	class:Byebug.CommandProcessor
+command_list.rb	lib/byebug/command_list.rb	1;"	F
+command_processor.rb	lib/byebug/processors/command_processor.rb	1;"	F
+command_processor_test.rb	test/processors/command_processor_test.rb	1;"	F
+commands	lib/byebug/helpers/reflection.rb	/^      def commands$/;"	f	class:Byebug.Helpers.ReflectionHelper
+commands	lib/byebug/processors/control_processor.rb	/^    def commands$/;"	f	class:Byebug.ControlProcessor
+commands	lib/byebug/processors/post_mortem_processor.rb	/^    def commands$/;"	f	class:Byebug.PostMortemProcessor
+commands	lib/byebug/processors/script_processor.rb	/^    def commands$/;"	f	class:Byebug.ScriptProcessor
+commands.rb	lib/byebug/commands.rb	1;"	F
+condition.rb	lib/byebug/commands/condition.rb	1;"	F
+condition_test.rb	test/commands/condition_test.rb	1;"	F
+confirm	lib/byebug/interface.rb	/^    def confirm(prompt)$/;"	f	class:Byebug.Interface
+confirm	lib/byebug/interfaces/remote_interface.rb	/^    def confirm(prompt)$/;"	f	class:Byebug.RemoteInterface
+connect_at	lib/byebug/remote/client.rb	/^      def connect_at(host, port)$/;"	f	class:Byebug.Remote.Client
+const.rb	lib/byebug/commands/var/const.rb	1;"	F
+contents	lib/byebug/printers/base.rb	/^      def contents$/;"	f	class:Byebug.Printers
+contents_files	lib/byebug/printers/base.rb	/^      def contents_files$/;"	f	class:Byebug.Printers
+contents_files	lib/byebug/printers/plain.rb	/^      def contents_files$/;"	f	class:Byebug.Printers
+context	lib/byebug/command.rb	/^    def context$/;"	f	class:Byebug.Command
+context	test/support/utils.rb	/^    def context$/;"	f	class:Byebug.TestUtils
+context.c	ext/byebug/context.c	1;"	F
+context.rb	lib/byebug/context.rb	1;"	F
+context_backtrace_set	ext/byebug/byebug.h	/^extern VALUE context_backtrace_set(const rb_debug_inspector_t *inspector,$/;"	p	signature:(const rb_debug_inspector_t *inspector, void *data)
+context_backtrace_set	ext/byebug/context.c	/^context_backtrace_set(const rb_debug_inspector_t *inspector, void *data)$/;"	f	signature:(const rb_debug_inspector_t *inspector, void *data)
+context_dup	ext/byebug/byebug.h	/^extern VALUE context_dup(debug_context_t *context);$/;"	p	signature:(debug_context_t *context)
+context_dup	ext/byebug/context.c	/^context_dup(debug_context_t *context)$/;"	f	signature:(debug_context_t *context)
+context_from_thread	lib/byebug/helpers/thread.rb	/^      def context_from_thread(thnum)$/;"	f	class:Byebug.Helpers.ThreadHelper
+context_mark	ext/byebug/context.c	/^context_mark(void *data)$/;"	f	file:	signature:(void *data)
+continue.rb	lib/byebug/commands/continue.rb	1;"	F
+continue_test.rb	test/commands/continue_test.rb	1;"	F
+control	lib/byebug/remote.rb	/^    def control$/;"	f	class:Byebug
+control_processor.rb	lib/byebug/processors/control_processor.rb	1;"	F
+core.rb	lib/byebug/core.rb	1;"	F
+create_threads_table	ext/byebug/byebug.h	/^extern VALUE create_threads_table(void);$/;"	p	signature:(void)
+create_threads_table	ext/byebug/threads.c	/^create_threads_table(void)$/;"	f	signature:(void)
+ctx	ext/byebug/byebug.h	/^  VALUE ctx;$/;"	m	struct:call_with_inspection_data	access:public
+ctx_stop_reason	ext/byebug/byebug.h	/^} ctx_stop_reason;$/;"	t	typeref:enum:__anon1
+curr_thnum	test/commands/thread_test.rb	/^    def curr_thnum$/;"	f
+current.rb	lib/byebug/commands/thread/current.rb	1;"	F
+current?	lib/byebug/frame.rb	/^    def current?$/;"	f	class:Byebug.Frame
+current_thread?	lib/byebug/helpers/thread.rb	/^      def current_thread?(ctx)$/;"	f	class:Byebug.Helpers.ThreadHelper
+dangling_descriptors	test/processors/script_processor_test.rb	/^    def dangling_descriptors$/;"	f	class:Byebug.ScriptProcessorTest
+dc	ext/byebug/byebug.h	/^  debug_context_t *dc;$/;"	m	struct:call_with_inspection_data	access:public
+dc_backtrace	ext/byebug/context.c	/^dc_backtrace(const debug_context_t *context)$/;"	f	file:	signature:(const debug_context_t *context)
+dc_frame_binding	ext/byebug/context.c	/^dc_frame_binding(const debug_context_t *context, int frame_index)$/;"	f	file:	signature:(const debug_context_t *context, int frame_index)
+dc_frame_class	ext/byebug/context.c	/^dc_frame_class(const debug_context_t *context, int frame_index)$/;"	f	file:	signature:(const debug_context_t *context, int frame_index)
+dc_frame_get	ext/byebug/context.c	/^dc_frame_get(const debug_context_t *context, int frame_index, frame_part type)$/;"	f	file:	signature:(const debug_context_t *context, int frame_index, frame_part type)
+dc_frame_location	ext/byebug/context.c	/^dc_frame_location(const debug_context_t *context, int frame_index)$/;"	f	file:	signature:(const debug_context_t *context, int frame_index)
+dc_frame_self	ext/byebug/context.c	/^dc_frame_self(const debug_context_t *context, int frame_index)$/;"	f	file:	signature:(const debug_context_t *context, int frame_index)
+dc_stack_size	ext/byebug/context.c	/^dc_stack_size(debug_context_t *context)$/;"	f	file:	signature:(debug_context_t *context)
+debug	lib/byebug/option_setter.rb	/^    def debug$/;"	f	class:Byebug.OptionSetter
+debug.rb	lib/byebug/commands/debug.rb	1;"	F
+debug_code	test/support/utils.rb	/^    def debug_code(program, &block)$/;"	f	class:Byebug.TestUtils
+debug_context_t	ext/byebug/byebug.h	/^} debug_context_t;$/;"	t	typeref:struct:__anon2
+debug_flag	lib/byebug/helpers/thread.rb	/^      def debug_flag(ctx)$/;"	f	class:Byebug.Helpers
+debug_in_temp_file	test/support/utils.rb	/^    def debug_in_temp_file(program)$/;"	f	class:Byebug.TestUtils
+debug_program	lib/byebug/runner.rb	/^    def debug_program$/;"	f	class:Byebug.Runner
+debug_test.rb	test/commands/debug_test.rb	1;"	F
+debugger_alias_test.rb	test/debugger_alias_test.rb	1;"	F
+deco_args	lib/byebug/frame.rb	/^    def deco_args$/;"	f	class:Byebug.Frame
+deco_block	lib/byebug/frame.rb	/^    def deco_block$/;"	f	class:Byebug.Frame
+deco_call	lib/byebug/frame.rb	/^    def deco_call$/;"	f	class:Byebug.Frame
+deco_class	lib/byebug/frame.rb	/^    def deco_class$/;"	f	class:Byebug.Frame
+deco_file	lib/byebug/frame.rb	/^    def deco_file$/;"	f	class:Byebug.Frame
+deco_method	lib/byebug/frame.rb	/^    def deco_method$/;"	f	class:Byebug.Frame
+deco_pos	lib/byebug/frame.rb	/^    def deco_pos$/;"	f	class:Byebug.Frame
+default_max_size	lib/byebug/history.rb	/^    def default_max_size$/;"	f	class:Byebug.to_s
+deindent	lib/byebug/helpers/string.rb	/^      def deindent(str, leading_spaces: 6)$/;"	f	class:Byebug.Helpers.StringHelper
+delete.rb	lib/byebug/commands/delete.rb	1;"	F
+delete_example_file	test/support/test_case.rb	/^    def delete_example_file$/;"	f	class:Byebug.TestCase
+delete_test.rb	test/commands/delete_test.rb	1;"	F
+description	lib/byebug/commands/break.rb	/^    def self.description$/;"	F	class:Byebug.BreakCommand
+description	lib/byebug/commands/catch.rb	/^    def self.description$/;"	F	class:Byebug.CatchCommand
+description	lib/byebug/commands/condition.rb	/^    def self.description$/;"	F	class:Byebug.ConditionCommand
+description	lib/byebug/commands/continue.rb	/^    def self.description$/;"	F	class:Byebug.ContinueCommand
+description	lib/byebug/commands/debug.rb	/^    def self.description$/;"	F	class:Byebug.DebugCommand
+description	lib/byebug/commands/delete.rb	/^    def self.description$/;"	F	class:Byebug.DeleteCommand
+description	lib/byebug/commands/disable.rb	/^    def self.description$/;"	F	class:Byebug.DisableCommand
+description	lib/byebug/commands/disable/breakpoints.rb	/^      def self.description$/;"	F	class:Byebug.DisableCommand.BreakpointsCommand
+description	lib/byebug/commands/disable/display.rb	/^      def self.description$/;"	F	class:Byebug.DisableCommand.DisplayCommand
+description	lib/byebug/commands/display.rb	/^    def self.description$/;"	F	class:Byebug.DisplayCommand
+description	lib/byebug/commands/down.rb	/^    def self.description$/;"	F	class:Byebug.DownCommand
+description	lib/byebug/commands/edit.rb	/^    def self.description$/;"	F	class:Byebug.EditCommand
+description	lib/byebug/commands/enable.rb	/^    def self.description$/;"	F	class:Byebug.EnableCommand
+description	lib/byebug/commands/enable/breakpoints.rb	/^      def self.description$/;"	F	class:Byebug.EnableCommand.BreakpointsCommand
+description	lib/byebug/commands/enable/display.rb	/^      def self.description$/;"	F	class:Byebug.EnableCommand.DisplayCommand
+description	lib/byebug/commands/finish.rb	/^    def self.description$/;"	F	class:Byebug.FinishCommand
+description	lib/byebug/commands/frame.rb	/^    def self.description$/;"	F	class:Byebug.FrameCommand
+description	lib/byebug/commands/help.rb	/^    def self.description$/;"	F	class:Byebug.HelpCommand
+description	lib/byebug/commands/history.rb	/^    def self.description$/;"	F	class:Byebug.HistoryCommand
+description	lib/byebug/commands/info.rb	/^    def self.description$/;"	F	class:Byebug.InfoCommand
+description	lib/byebug/commands/info/breakpoints.rb	/^      def self.description$/;"	F	class:Byebug.InfoCommand.BreakpointsCommand
+description	lib/byebug/commands/info/display.rb	/^      def self.description$/;"	F	class:Byebug.InfoCommand.DisplayCommand
+description	lib/byebug/commands/info/file.rb	/^      def self.description$/;"	F	class:Byebug.InfoCommand.FileCommand
+description	lib/byebug/commands/info/line.rb	/^      def self.description$/;"	F	class:Byebug.InfoCommand.LineCommand
+description	lib/byebug/commands/info/program.rb	/^      def self.description$/;"	F	class:Byebug.InfoCommand.ProgramCommand
+description	lib/byebug/commands/interrupt.rb	/^    def self.description$/;"	F	class:Byebug.InterruptCommand
+description	lib/byebug/commands/irb.rb	/^    def self.description$/;"	F	class:Byebug.IrbCommand
+description	lib/byebug/commands/kill.rb	/^    def self.description$/;"	F	class:Byebug.KillCommand
+description	lib/byebug/commands/list.rb	/^    def self.description$/;"	F	class:Byebug.ListCommand
+description	lib/byebug/commands/method.rb	/^    def self.description$/;"	F	class:Byebug.MethodCommand
+description	lib/byebug/commands/next.rb	/^    def self.description$/;"	F	class:Byebug.NextCommand
+description	lib/byebug/commands/pry.rb	/^    def self.description$/;"	F	class:Byebug.PryCommand
+description	lib/byebug/commands/quit.rb	/^    def self.description$/;"	F	class:Byebug.QuitCommand
+description	lib/byebug/commands/restart.rb	/^    def self.description$/;"	F	class:Byebug.RestartCommand
+description	lib/byebug/commands/save.rb	/^    def self.description$/;"	F	class:Byebug.SaveCommand
+description	lib/byebug/commands/set.rb	/^    def self.description$/;"	F	class:Byebug.SetCommand
+description	lib/byebug/commands/show.rb	/^    def self.description$/;"	F	class:Byebug.ShowCommand
+description	lib/byebug/commands/skip.rb	/^    def self.description$/;"	F	class:Byebug
+description	lib/byebug/commands/source.rb	/^    def self.description$/;"	F	class:Byebug.SourceCommand
+description	lib/byebug/commands/step.rb	/^    def self.description$/;"	F	class:Byebug.StepCommand
+description	lib/byebug/commands/thread.rb	/^    def self.description$/;"	F	class:Byebug.ThreadCommand
+description	lib/byebug/commands/thread/current.rb	/^      def self.description$/;"	F	class:Byebug.ThreadCommand.CurrentCommand
+description	lib/byebug/commands/thread/list.rb	/^      def self.description$/;"	F	class:Byebug.ThreadCommand.ListCommand
+description	lib/byebug/commands/thread/resume.rb	/^      def self.description$/;"	F	class:Byebug.ThreadCommand.ResumeCommand
+description	lib/byebug/commands/thread/stop.rb	/^      def self.description$/;"	F	class:Byebug.ThreadCommand.StopCommand
+description	lib/byebug/commands/thread/switch.rb	/^      def self.description$/;"	F	class:Byebug.ThreadCommand.SwitchCommand
+description	lib/byebug/commands/tracevar.rb	/^    def self.description$/;"	F	class:Byebug.TracevarCommand
+description	lib/byebug/commands/undisplay.rb	/^    def self.description$/;"	F	class:Byebug.UndisplayCommand
+description	lib/byebug/commands/untracevar.rb	/^    def self.description$/;"	F	class:Byebug.UntracevarCommand
+description	lib/byebug/commands/up.rb	/^    def self.description$/;"	F	class:Byebug.UpCommand
+description	lib/byebug/commands/var.rb	/^    def self.description$/;"	F	class:Byebug.VarCommand
+description	lib/byebug/commands/var/all.rb	/^      def self.description$/;"	F	class:Byebug.VarCommand.AllCommand
+description	lib/byebug/commands/var/args.rb	/^      def self.description$/;"	F	class:Byebug.VarCommand.ArgsCommand
+description	lib/byebug/commands/var/const.rb	/^      def self.description$/;"	F	class:Byebug.VarCommand.ConstCommand
+description	lib/byebug/commands/var/global.rb	/^      def self.description$/;"	F	class:Byebug.VarCommand.GlobalCommand
+description	lib/byebug/commands/var/instance.rb	/^      def self.description$/;"	F	class:Byebug.VarCommand.InstanceCommand
+description	lib/byebug/commands/var/local.rb	/^      def self.description$/;"	F	class:Byebug.VarCommand.LocalCommand
+description	lib/byebug/commands/where.rb	/^    def self.description$/;"	F	class:Byebug.WhereCommand
+dest_frame	ext/byebug/byebug.h	/^  int dest_frame; \/* next stop's frame if stopped by next     *\/$/;"	m	struct:__anon2	access:public
+direction	lib/byebug/helpers/frame.rb	/^      def direction(step)$/;"	f	class:Byebug.Helpers.FrameHelper
+disable.rb	lib/byebug/commands/disable.rb	1;"	F
+disable_test.rb	test/commands/disable_test.rb	1;"	F
+display.rb	lib/byebug/commands/disable/display.rb	1;"	F
+display.rb	lib/byebug/commands/display.rb	1;"	F
+display.rb	lib/byebug/commands/enable/display.rb	1;"	F
+display.rb	lib/byebug/commands/info/display.rb	1;"	F
+display_context	lib/byebug/helpers/thread.rb	/^      def display_context(ctx)$/;"	f	class:Byebug.Helpers.ThreadHelper
+display_expression	lib/byebug/commands/display.rb	/^    def display_expression(exp)$/;"	f	class:Byebug.DisplayCommand
+display_lines	lib/byebug/commands/list.rb	/^    def display_lines(min, max)$/;"	f	class:Byebug.ListCommand
+display_test.rb	test/commands/display_test.rb	1;"	F
+down.rb	lib/byebug/commands/down.rb	1;"	F
+down_test.rb	test/commands/down_test.rb	1;"	F
+download_sha256	docker/manager.rb	/^    def download_sha256$/;"	f	class:Docker
+download_url	docker/manager.rb	/^    def download_url$/;"	f	class:Docker
+download_url_base	docker/manager.rb	/^    def download_url_base$/;"	f	class:Docker
+dt_inherited	ext/byebug/context.c	/^dt_inherited(VALUE klass)$/;"	f	file:	signature:(VALUE klass)
+each	lib/byebug/command_list.rb	/^    def each$/;"	f	class:Byebug.CommandList
+edit.rb	lib/byebug/commands/edit.rb	1;"	F
+edit_error	lib/byebug/commands/edit.rb	/^    def edit_error(type, file)$/;"	f	class:Byebug.EditCommand
+edit_test.rb	test/commands/edit_test.rb	1;"	F
+editor	lib/byebug/commands/edit.rb	/^    def editor$/;"	f	class:Byebug.EditCommand
+enable.rb	lib/byebug/commands/enable.rb	1;"	F
+enable_disable_breakpoints	lib/byebug/helpers/toggle.rb	/^      def enable_disable_breakpoints(is_enable, args)$/;"	f	class:Byebug.Helpers.ToggleHelper
+enable_disable_display	lib/byebug/helpers/toggle.rb	/^      def enable_disable_display(is_enable, args)$/;"	f	class:Byebug.Helpers.ToggleHelper
+enable_test.rb	test/commands/enable_test.rb	1;"	F
+enabled	ext/byebug/byebug.h	/^  VALUE enabled;$/;"	m	struct:__anon5	access:public
+end_event	ext/byebug/byebug.c	/^end_event(VALUE trace_point, void *data)$/;"	f	file:	signature:(VALUE trace_point, void *data)
+enter	test/support/utils.rb	/^    def enter(*messages)$/;"	f	class:Byebug.TestUtils
+errmsg	lib/byebug/interface.rb	/^    def errmsg(message)$/;"	f	class:Byebug.Interface
+errmsg	lib/byebug/interfaces/test_interface.rb	/^    def errmsg(message)$/;"	f	class:Byebug.TestInterface
+error_eval	lib/byebug/helpers/eval.rb	/^      def error_eval(str, binding = frame._binding)$/;"	f	class:Byebug.Helpers.EvalHelper
+error_in_script?	lib/byebug/runner.rb	/^    def error_in_script?$/;"	f	class:Byebug.Runner
+error_msg	lib/byebug/helpers/eval.rb	/^      def error_msg(exception)$/;"	f	class:Byebug.Helpers.EvalHelper
+errors.rb	lib/byebug/errors.rb	1;"	F
+eval.rb	lib/byebug/helpers/eval.rb	1;"	F
+eval_expr	lib/byebug/commands/display.rb	/^    def eval_expr(expression)$/;"	f	class:Byebug
+eval_expression	ext/byebug/breakpoint.c	/^eval_expression(VALUE args)$/;"	f	file:	signature:(VALUE args)
+example_class	test/support/test_case.rb	/^    def example_class$/;"	f	class:Byebug.TestCase
+example_file	test/support/test_case.rb	/^    def example_file$/;"	f	class:Byebug.TestCase
+example_folder	test/support/test_case.rb	/^    def example_folder$/;"	f	class:Byebug.TestCase
+example_full_class	test/support/test_case.rb	/^    def example_full_class$/;"	f	class:Byebug.TestCase
+example_module	test/support/test_case.rb	/^    def example_module$/;"	f	class:Byebug.TestCase
+example_path	test/support/test_case.rb	/^    def example_path$/;"	f	class:Byebug.TestCase
+executable_file_extensions	lib/byebug/helpers/bin.rb	/^      def executable_file_extensions$/;"	f	class:Byebug.Helpers.BinHelper
+execute	lib/byebug/commands/break.rb	/^    def execute$/;"	f	class:Byebug.BreakCommand.description
+execute	lib/byebug/commands/catch.rb	/^    def execute$/;"	f	class:Byebug.CatchCommand
+execute	lib/byebug/commands/condition.rb	/^    def execute$/;"	f	class:Byebug.ConditionCommand
+execute	lib/byebug/commands/continue.rb	/^    def execute$/;"	f	class:Byebug.ContinueCommand
+execute	lib/byebug/commands/debug.rb	/^    def execute$/;"	f	class:Byebug.DebugCommand
+execute	lib/byebug/commands/delete.rb	/^    def execute$/;"	f	class:Byebug.DeleteCommand
+execute	lib/byebug/commands/disable/breakpoints.rb	/^      def execute$/;"	f	class:Byebug.DisableCommand.BreakpointsCommand
+execute	lib/byebug/commands/disable/display.rb	/^      def execute$/;"	f	class:Byebug.DisableCommand.DisplayCommand
+execute	lib/byebug/commands/display.rb	/^    def execute$/;"	f	class:Byebug.DisplayCommand
+execute	lib/byebug/commands/down.rb	/^    def execute$/;"	f	class:Byebug.DownCommand
+execute	lib/byebug/commands/edit.rb	/^    def execute$/;"	f	class:Byebug.EditCommand
+execute	lib/byebug/commands/enable/breakpoints.rb	/^      def execute$/;"	f	class:Byebug.EnableCommand.BreakpointsCommand
+execute	lib/byebug/commands/enable/display.rb	/^      def execute$/;"	f	class:Byebug.EnableCommand.DisplayCommand
+execute	lib/byebug/commands/finish.rb	/^    def execute$/;"	f	class:Byebug.FinishCommand
+execute	lib/byebug/commands/frame.rb	/^    def execute$/;"	f	class:Byebug.FrameCommand
+execute	lib/byebug/commands/help.rb	/^    def execute$/;"	f	class:Byebug.HelpCommand
+execute	lib/byebug/commands/history.rb	/^    def execute$/;"	f	class:Byebug.HistoryCommand
+execute	lib/byebug/commands/info/breakpoints.rb	/^      def execute$/;"	f	class:Byebug.InfoCommand.BreakpointsCommand
+execute	lib/byebug/commands/info/display.rb	/^      def execute$/;"	f	class:Byebug.InfoCommand.DisplayCommand
+execute	lib/byebug/commands/info/file.rb	/^      def execute$/;"	f	class:Byebug.InfoCommand.FileCommand
+execute	lib/byebug/commands/info/line.rb	/^      def execute$/;"	f	class:Byebug.InfoCommand.LineCommand
+execute	lib/byebug/commands/info/program.rb	/^      def execute$/;"	f	class:Byebug.InfoCommand.ProgramCommand
+execute	lib/byebug/commands/interrupt.rb	/^    def execute$/;"	f	class:Byebug.InterruptCommand
+execute	lib/byebug/commands/irb.rb	/^    def execute$/;"	f	class:Byebug.IrbCommand
+execute	lib/byebug/commands/kill.rb	/^    def execute$/;"	f	class:Byebug.KillCommand
+execute	lib/byebug/commands/list.rb	/^    def execute$/;"	f	class:Byebug.ListCommand
+execute	lib/byebug/commands/method.rb	/^    def execute$/;"	f	class:Byebug.MethodCommand.description
+execute	lib/byebug/commands/next.rb	/^    def execute$/;"	f	class:Byebug.NextCommand
+execute	lib/byebug/commands/pry.rb	/^    def execute$/;"	f	class:Byebug.PryCommand
+execute	lib/byebug/commands/quit.rb	/^    def execute$/;"	f	class:Byebug.QuitCommand
+execute	lib/byebug/commands/restart.rb	/^    def execute$/;"	f	class:Byebug.RestartCommand
+execute	lib/byebug/commands/save.rb	/^    def execute$/;"	f	class:Byebug.SaveCommand
+execute	lib/byebug/commands/set.rb	/^    def execute$/;"	f	class:Byebug.SetCommand
+execute	lib/byebug/commands/show.rb	/^    def execute$/;"	f	class:Byebug.ShowCommand
+execute	lib/byebug/commands/skip.rb	/^    def execute$/;"	f	class:Byebug
+execute	lib/byebug/commands/source.rb	/^    def execute$/;"	f	class:Byebug.SourceCommand
+execute	lib/byebug/commands/step.rb	/^    def execute$/;"	f	class:Byebug.StepCommand
+execute	lib/byebug/commands/thread/current.rb	/^      def execute$/;"	f	class:Byebug.ThreadCommand.CurrentCommand
+execute	lib/byebug/commands/thread/list.rb	/^      def execute$/;"	f	class:Byebug.ThreadCommand.ListCommand
+execute	lib/byebug/commands/thread/resume.rb	/^      def execute$/;"	f	class:Byebug.ThreadCommand.ResumeCommand
+execute	lib/byebug/commands/thread/stop.rb	/^      def execute$/;"	f	class:Byebug.ThreadCommand.StopCommand
+execute	lib/byebug/commands/thread/switch.rb	/^      def execute$/;"	f	class:Byebug.ThreadCommand.SwitchCommand
+execute	lib/byebug/commands/tracevar.rb	/^    def execute$/;"	f	class:Byebug.TracevarCommand
+execute	lib/byebug/commands/undisplay.rb	/^    def execute$/;"	f	class:Byebug.UndisplayCommand
+execute	lib/byebug/commands/untracevar.rb	/^    def execute$/;"	f	class:Byebug.UntracevarCommand
+execute	lib/byebug/commands/up.rb	/^    def execute$/;"	f	class:Byebug.UpCommand
+execute	lib/byebug/commands/var/all.rb	/^      def execute$/;"	f	class:Byebug.VarCommand.AllCommand
+execute	lib/byebug/commands/var/args.rb	/^      def execute$/;"	f	class:Byebug.VarCommand.ArgsCommand
+execute	lib/byebug/commands/var/const.rb	/^      def execute$/;"	f	class:Byebug.VarCommand.ConstCommand
+execute	lib/byebug/commands/var/global.rb	/^      def execute$/;"	f	class:Byebug.VarCommand.GlobalCommand
+execute	lib/byebug/commands/var/instance.rb	/^      def execute$/;"	f	class:Byebug.VarCommand.InstanceCommand
+execute	lib/byebug/commands/var/local.rb	/^      def execute$/;"	f	class:Byebug.VarCommand.LocalCommand
+execute	lib/byebug/commands/where.rb	/^    def execute$/;"	f	class:Byebug.WhereCommand
+execute	lib/byebug/subcommands.rb	/^    def execute$/;"	f	class:Byebug.Subcommands
+expr	ext/byebug/byebug.h	/^  VALUE expr;$/;"	m	struct:__anon5	access:public
+extconf.rb	ext/byebug/extconf.rb	1;"	F
+extract_from_argv	test/minitest_runner.rb	/^    def extract_from_argv$/;"	f	class:Byebug.filter_runnables
+failure_message_for	tasks/linter.rb	/^  def failure_message_for(offenses)$/;"	f	class:LinterMixin
+faking_exit!	test/commands/quit_test.rb	/^    def faking_exit!$/;"	f	class:Byebug.QuitTest
+file	lib/byebug/frame.rb	/^    def file$/;"	f	class:Byebug.Frame
+file.rb	lib/byebug/commands/info/file.rb	1;"	F
+file.rb	lib/byebug/helpers/file.rb	1;"	F
+file_contents	test/commands/save_test.rb	/^    def file_contents$/;"	f	class:Byebug
+file_line	lib/byebug/commands/skip.rb	/^      def file_line$/;"	f	class:Byebug.SkipCommand
+file_path	lib/byebug/commands/skip.rb	/^      def file_path$/;"	f	class:Byebug.SkipCommand
+filename_cmp	ext/byebug/breakpoint.c	/^filename_cmp(VALUE source, char *file)$/;"	f	file:	signature:(VALUE source, char *file)
+filename_cmp_impl	ext/byebug/breakpoint.c	/^filename_cmp_impl(VALUE source, char *file)$/;"	f	file:	signature:(VALUE source, char *file)
+filter_runnables	test/minitest_runner.rb	/^    def filter_runnables$/;"	f	class:Byebug
+filter_runnables_by_class	test/minitest_runner.rb	/^    def filter_runnables_by_class(str)$/;"	f	class:Byebug
+filter_runnables_by_method	test/minitest_runner.rb	/^    def filter_runnables_by_method(str)$/;"	f	class:Byebug
+filtered_methods	test/minitest_runner.rb	/^    def filtered_methods$/;"	f	class:Byebug.filter_runnables
+find	lib/byebug/setting.rb	/^      def find(shortcut)$/;"	f	class:Byebug.Setting
+find_breakpoint_by_method	ext/byebug/breakpoint.c	/^find_breakpoint_by_method(VALUE breakpoints, VALUE klass, ID mid, VALUE bind,$/;"	f	signature:(VALUE breakpoints, VALUE klass, ID mid, VALUE bind, VALUE self)
+find_breakpoint_by_method	ext/byebug/byebug.h	/^extern VALUE find_breakpoint_by_method(VALUE breakpoints, VALUE klass,$/;"	p	signature:(VALUE breakpoints, VALUE klass, VALUE mid, VALUE bind, VALUE self)
+find_breakpoint_by_pos	ext/byebug/breakpoint.c	/^find_breakpoint_by_pos(VALUE breakpoints, VALUE source, VALUE pos, VALUE bind)$/;"	f	signature:(VALUE breakpoints, VALUE source, VALUE pos, VALUE bind)
+find_breakpoint_by_pos	ext/byebug/byebug.h	/^extern VALUE find_breakpoint_by_pos(VALUE breakpoints, VALUE source, VALUE pos,$/;"	p	signature:(VALUE breakpoints, VALUE source, VALUE pos, VALUE bind)
+find_executable	lib/byebug/helpers/bin.rb	/^      def find_executable(path, cmd)$/;"	f	class:Byebug.Helpers.BinHelper
+finish.rb	lib/byebug/commands/finish.rb	1;"	F
+finish_test.rb	test/commands/finish_test.rb	1;"	F
+first	lib/byebug/breakpoint.rb	/^    def self.first$/;"	F	class:Byebug.Breakpoint
+fixing_cmd	tasks/linter.rb	/^  def fixing_cmd(offenses)$/;"	f	class:CLangFormatLinter
+flags	ext/byebug/byebug.h	/^  int flags;$/;"	m	struct:__anon2	access:public
+for_all_images	docker/manager.rb	/^      def for_all_images(&block)$/;"	f	class:Docker.Manager
+for_last_version_variants	docker/manager.rb	/^      def for_last_version_variants(&block)$/;"	f	class:Docker.Manager
+for_variants_of	docker/manager.rb	/^      def for_variants_of(version)$/;"	f	class:Docker.Manager
+force_remove_const	test/support/utils.rb	/^    def force_remove_const(klass, const)$/;"	f	class:Byebug.TestUtils
+format_stop_reason	lib/byebug/commands/info/program.rb	/^      def format_stop_reason(stop_reason)$/;"	f	class:Byebug.InfoCommand.ProgramCommand
+frame	lib/byebug/command.rb	/^    def frame$/;"	f	class:Byebug.Command
+frame	lib/byebug/context.rb	/^    def frame$/;"	f	class:Byebug
+frame	test/support/utils.rb	/^    def frame$/;"	f	class:Byebug.TestUtils
+frame.rb	lib/byebug/commands/frame.rb	1;"	F
+frame.rb	lib/byebug/frame.rb	1;"	F
+frame.rb	lib/byebug/helpers/frame.rb	1;"	F
+frame=	lib/byebug/context.rb	/^    def frame=(pos)$/;"	f	class:Byebug
+frame_err	lib/byebug/helpers/frame.rb	/^      def frame_err(msg)$/;"	f	class:Byebug.Helpers.FrameHelper
+frame_part	ext/byebug/byebug.h	/^} frame_part;$/;"	t	typeref:enum:__anon3
+frame_test.rb	test/commands/frame_test.rb	1;"	F
+full_help	test/runner_without_target_program_test.rb	/^    def full_help$/;"	f	class:Byebug.RunnerWithoutTargetProgramTest
+full_location	lib/byebug/context.rb	/^    def full_location$/;"	f	class:Byebug
+full_version	test/runner_without_target_program_test.rb	/^    def full_version$/;"	f	class:Byebug.RunnerWithoutTargetProgramTest
+fullpath.rb	lib/byebug/settings/fullpath.rb	1;"	F
+gem_files	lib/byebug/helpers/path.rb	/^      def gem_files$/;"	f	class:Byebug.Helpers.PathHelper
+gemfile	bin/bundle	/^  def gemfile$/;"	f
+get_int	lib/byebug/helpers/parse.rb	/^      def get_int(str, cmd, min = nil, max = nil)$/;"	f	class:Byebug.Helpers.ParseHelper
+get_line	lib/byebug/helpers/file.rb	/^      def get_line(filename, lineno)$/;"	f	class:Byebug.Helpers.FileHelper
+get_lines	lib/byebug/helpers/file.rb	/^      def get_lines(filename)$/;"	f	class:Byebug.Helpers.FileHelper
+get_onoff	lib/byebug/commands/set.rb	/^    def get_onoff(arg, default)$/;"	f	class:Byebug.SetCommand
+glob_for	lib/byebug/helpers/path.rb	/^      def glob_for(dir)$/;"	f	class:Byebug.Helpers.PathHelper
+global.rb	lib/byebug/commands/var/global.rb	1;"	F
+handle_post_mortem	lib/byebug/core.rb	/^  def self.handle_post_mortem$/;"	F
+help	lib/byebug/command.rb	/^      def help$/;"	f	class:Byebug.Command
+help	lib/byebug/commands/set.rb	/^    def self.help$/;"	F	class:Byebug.SetCommand
+help	lib/byebug/commands/show.rb	/^    def self.help$/;"	F	class:Byebug.ShowCommand
+help	lib/byebug/errors.rb	/^    def help$/;"	f	class:Byebug.CommandNotFound
+help	lib/byebug/option_setter.rb	/^    def help$/;"	f
+help	lib/byebug/setting.rb	/^    def help$/;"	f	class:Byebug.Setting
+help	lib/byebug/subcommands.rb	/^      def help$/;"	f	class:Byebug.Subcommands.ClassMethods
+help.rb	lib/byebug/commands/help.rb	1;"	F
+help=	lib/byebug/runner.rb	/^    def help=(text)$/;"	f	class:Byebug.Runner
+help_all	lib/byebug/setting.rb	/^      def help_all$/;"	f	class:Byebug.Setting
+help_for	lib/byebug/commands/help.rb	/^    def help_for(input, cmd)$/;"	f	class:Byebug.HelpCommand
+help_for_all	lib/byebug/commands/help.rb	/^    def help_for_all$/;"	f	class:Byebug.HelpCommand
+help_test.rb	test/commands/help_test.rb	1;"	F
+histfile.rb	lib/byebug/settings/histfile.rb	1;"	F
+history.rb	lib/byebug/commands/history.rb	1;"	F
+history.rb	lib/byebug/history.rb	1;"	F
+history_test.rb	test/commands/history_test.rb	1;"	F
+histsize.rb	lib/byebug/settings/histsize.rb	1;"	F
+hit_condition	ext/byebug/byebug.h	/^  enum hit_condition hit_condition;$/;"	m	struct:__anon5	typeref:enum:__anon5::hit_condition	access:public
+hit_condition	ext/byebug/byebug.h	/^enum hit_condition$/;"	g
+hit_count	ext/byebug/byebug.h	/^  int hit_count;$/;"	m	struct:__anon5	access:public
+hit_value	ext/byebug/byebug.h	/^  int hit_value;$/;"	m	struct:__anon5	access:public
+id	ext/byebug/byebug.h	/^  ID id;$/;"	m	struct:call_with_inspection_data	access:public
+id	ext/byebug/byebug.h	/^  int id;$/;"	m	struct:__anon5	access:public
+idEmpty	ext/byebug/byebug.c	/^static ID idEmpty;$/;"	v	file:
+idEval	ext/byebug/breakpoint.c	/^static ID idEval;$/;"	v	file:
+idPuts	ext/byebug/byebug.c	/^static ID idPuts;$/;"	v	file:
+ignore?	lib/byebug/history.rb	/^    def ignore?(buf)$/;"	f	class:Byebug.to_s
+ignored_file?	lib/byebug/context.rb	/^    def ignored_file?(path)$/;"	f	class:Byebug
+ignored_files	lib/byebug/context.rb	/^      def ignored_files$/;"	f	class:Byebug.Context
+in_new_thread	lib/byebug/helpers/eval.rb	/^      def in_new_thread$/;"	f	class:Byebug.Helpers.EvalHelper
+include_flag	lib/byebug/option_setter.rb	/^    def include_flag$/;"	f	class:Byebug
+included	lib/byebug/subcommands.rb	/^    def self.included(command)$/;"	F	class:Byebug.Subcommands
+includes_in_order	test/support/assertions.rb	/^    def includes_in_order(collection, original_collection)$/;"	f	class:Minitest.Assertions
+index_from_start	lib/byebug/helpers/frame.rb	/^      def index_from_start(index)$/;"	f	class:Byebug.Helpers.FrameHelper
+info	lib/byebug/commands/catch.rb	/^    def info$/;"	f	class:Byebug.CatchCommand
+info.rb	lib/byebug/commands/info.rb	1;"	F
+info_breakpoint	lib/byebug/commands/info/breakpoints.rb	/^      def info_breakpoint(brkpt)$/;"	f	class:Byebug.InfoCommand.BreakpointsCommand
+info_file_basic	lib/byebug/commands/info/file.rb	/^      def info_file_basic(file)$/;"	f	class:Byebug.InfoCommand.FileCommand
+info_file_breakpoints	lib/byebug/commands/info/file.rb	/^      def info_file_breakpoints(file)$/;"	f	class:Byebug.InfoCommand.FileCommand
+info_file_mtime	lib/byebug/commands/info/file.rb	/^      def info_file_mtime(file)$/;"	f	class:Byebug.InfoCommand.FileCommand
+info_file_sha1	lib/byebug/commands/info/file.rb	/^      def info_file_sha1(file)$/;"	f	class:Byebug.InfoCommand.FileCommand
+info_test.rb	test/commands/info_test.rb	1;"	F
+init_script	lib/byebug/runner.rb	/^    def init_script$/;"	f	class:Byebug.Runner
+initialize	docker/manager.rb	/^    def initialize(version:, line_editor:, compiler:)$/;"	f	class:Docker.Manager
+initialize	lib/byebug/command.rb	/^    def initialize(processor, input = self.class.to_s)$/;"	f	class:Byebug.Command
+initialize	lib/byebug/command_list.rb	/^    def initialize(commands)$/;"	f	class:Byebug.CommandList
+initialize	lib/byebug/errors.rb	/^    def initialize(input, parent = nil)$/;"	f	class:Byebug.CommandNotFound
+initialize	lib/byebug/frame.rb	/^    def initialize(context, pos)$/;"	f	class:Byebug.Frame
+initialize	lib/byebug/history.rb	/^    def initialize$/;"	f	class:Byebug.History
+initialize	lib/byebug/interface.rb	/^    def initialize$/;"	f	class:Byebug.Interface
+initialize	lib/byebug/interfaces/local_interface.rb	/^    def initialize$/;"	f	class:Byebug.LocalInterface
+initialize	lib/byebug/interfaces/remote_interface.rb	/^    def initialize(socket)$/;"	f	class:Byebug.RemoteInterface
+initialize	lib/byebug/interfaces/script_interface.rb	/^    def initialize(file, verbose = false)$/;"	f	class:Byebug.ScriptInterface
+initialize	lib/byebug/interfaces/test_interface.rb	/^    def initialize$/;"	f	class:Byebug.TestInterface
+initialize	lib/byebug/option_setter.rb	/^    def initialize(runner, opts)$/;"	f	class:Byebug.OptionSetter
+initialize	lib/byebug/processors/command_processor.rb	/^    def initialize(context, interface = LocalInterface.new)$/;"	f	class:Byebug.CommandProcessor
+initialize	lib/byebug/remote/client.rb	/^      def initialize(interface)$/;"	f	class:Byebug.Remote.Client
+initialize	lib/byebug/remote/server.rb	/^      def initialize(wait_connection:, &block)$/;"	f	class:Byebug.Remote.Server
+initialize	lib/byebug/runner.rb	/^    def initialize(stop = true, quit = true)$/;"	f	class:Byebug.Runner
+initialize	lib/byebug/setting.rb	/^    def initialize$/;"	f	class:Byebug.Setting
+initialize	lib/byebug/settings/autoirb.rb	/^    def initialize$/;"	f	class:Byebug.AutoirbSetting
+initialize	lib/byebug/settings/autolist.rb	/^    def initialize$/;"	f	class:Byebug.AutolistSetting
+initialize	lib/byebug/settings/autopry.rb	/^    def initialize$/;"	f	class:Byebug.AutoprySetting
+initialize	lib/byebug/settings/post_mortem.rb	/^    def initialize$/;"	f	class:Byebug.PostMortemSetting
+initialize	lib/byebug/source_file_formatter.rb	/^    def initialize(file, annotator)$/;"	f	class:Byebug.SourceFileFormatter
+initialize	test/minitest_runner.rb	/^    def initialize$/;"	f	class:Byebug.MinitestRunner
+initialize	test/processors/command_processor_test.rb	/^            def initialize$/;"	f	class:ProcessorEvaluationAndThreadsTest.program.Byebug
+initialize_attributes	lib/byebug/commands/skip.rb	/^    def initialize_attributes$/;"	f	class:Byebug
+inspect	lib/byebug/breakpoint.rb	/^    def inspect$/;"	f	class:Byebug.Breakpoint
+inspect	lib/byebug/interfaces/test_interface.rb	/^    def inspect$/;"	f	class:Byebug.TestInterface
+instance.rb	lib/byebug/commands/var/instance.rb	1;"	F
+integer?	lib/byebug/setting.rb	/^    def integer?$/;"	f	class:Byebug.Setting
+interface	lib/byebug/context.rb	/^      def interface$/;"	f	class:Byebug.Context
+interface	lib/byebug/runner.rb	/^    def interface$/;"	f	class:Byebug.Runner
+interface	test/support/utils.rb	/^    def interface$/;"	f	class:Byebug.TestUtils
+interface.rb	lib/byebug/interface.rb	1;"	F
+interface_test.rb	test/interface_test.rb	1;"	F
+interrupt	lib/byebug/context.rb	/^    def interrupt$/;"	f	class:Byebug
+interrupt	lib/byebug/remote.rb	/^    def interrupt$/;"	f	class:Byebug
+interrupt.rb	lib/byebug/commands/interrupt.rb	1;"	F
+interrupt_test.rb	test/commands/interrupt_test.rb	1;"	F
+invalid_script?	lib/byebug/runner.rb	/^    def invalid_script?$/;"	f	class:Byebug.Runner
+irb.rb	lib/byebug/commands/irb.rb	1;"	F
+irb_test.rb	test/commands/irb_test.rb	1;"	F
+is_in_locked	ext/byebug/locker.c	/^is_in_locked(VALUE thread)$/;"	f	file:	signature:(VALUE thread)
+is_living_thread	ext/byebug/byebug.h	/^extern int is_living_thread(VALUE thread);$/;"	p	signature:(VALUE thread)
+is_living_thread	ext/byebug/threads.c	/^is_living_thread(VALUE thread)$/;"	f	signature:(VALUE thread)
+isdirsep	ext/byebug/breakpoint.c	10;"	d	file:
+isdirsep	ext/byebug/breakpoint.c	8;"	d	file:
+jump_frames	lib/byebug/helpers/frame.rb	/^      def jump_frames(steps)$/;"	f	class:Byebug.Helpers.FrameHelper
+keep_execution	lib/byebug/commands/skip.rb	/^    def keep_execution$/;"	f	class:Byebug
+kill.rb	lib/byebug/commands/kill.rb	1;"	F
+kill_test.rb	test/commands/kill_test.rb	1;"	F
+klass	test/printers/plain_test.rb	/^    def klass$/;"	f	class:Byebug.PrintersPlainTest
+last	lib/byebug/breakpoint.rb	/^    def self.last$/;"	F	class:Byebug.Breakpoint
+last_ids	lib/byebug/history.rb	/^    def last_ids(number)$/;"	f	class:Byebug.to_s
+last_if_empty	lib/byebug/interface.rb	/^    def last_if_empty(input)$/;"	f	class:Byebug.Interface
+launch_client	test/support/remote_debugging_tests.rb	/^    def launch_client$/;"	f	class:Byebug
+lib_files	lib/byebug/helpers/path.rb	/^      def lib_files$/;"	f	class:Byebug.Helpers.PathHelper
+line	ext/byebug/byebug.h	/^    int line;$/;"	m	union:__anon5::__anon6	access:public
+line	lib/byebug/frame.rb	/^    def line$/;"	f	class:Byebug.Frame
+line.rb	lib/byebug/commands/info/line.rb	1;"	F
+line_breakpoint	lib/byebug/commands/break.rb	/^    def line_breakpoint(location)$/;"	f	class:Byebug.BreakCommand.description
+line_editor_configure_flag	docker/manager.rb	/^    def line_editor_configure_flag$/;"	f	class:Docker
+line_editor_package	docker/manager.rb	/^    def line_editor_package$/;"	f	class:Docker
+line_event	ext/byebug/byebug.c	/^line_event(VALUE trace_point, void *data)$/;"	f	file:	signature:(VALUE trace_point, void *data)
+lines	ext/byebug/byebug.h	/^  int lines;      \/* # of lines in dest_frame before stopping *\/$/;"	m	struct:__anon2	access:public
+lines	lib/byebug/source_file_formatter.rb	/^    def lines(min, max)$/;"	f	class:Byebug.SourceFileFormatter
+lines_around	lib/byebug/source_file_formatter.rb	/^    def lines_around(center)$/;"	f	class:Byebug.SourceFileFormatter
+linetrace.rb	lib/byebug/settings/linetrace.rb	1;"	F
+linter.rb	tasks/linter.rb	1;"	F
+list.rb	lib/byebug/commands/list.rb	1;"	F
+list.rb	lib/byebug/commands/thread/list.rb	1;"	F
+list_test.rb	test/commands/list_test.rb	1;"	F
+listsize.rb	lib/byebug/settings/listsize.rb	1;"	F
+load_backtrace	ext/byebug/context.c	/^load_backtrace(const rb_debug_inspector_t *inspector)$/;"	f	file:	signature:(const rb_debug_inspector_t *inspector)
+load_bundler!	bin/bundle	/^  def load_bundler!$/;"	f
+load_settings	lib/byebug/core.rb	/^  def self.load_settings$/;"	F	class:Byebug
+local.rb	lib/byebug/commands/var/local.rb	1;"	F
+local_interface.rb	lib/byebug/interfaces/local_interface.rb	1;"	F
+local_interface_test.rb	test/interfaces/local_interface_test.rb	1;"	F
+locals	lib/byebug/frame.rb	/^    def locals$/;"	f	class:Byebug.Frame
+locate	lib/byebug/printers/base.rb	/^      def locate(path)$/;"	f	class:Byebug.Printers.Base
+location	lib/byebug/commands/edit.rb	/^    def location(matched)$/;"	f	class:Byebug.EditCommand
+location	lib/byebug/context.rb	/^    def location$/;"	f	class:Byebug
+location	lib/byebug/helpers/thread.rb	/^      def location(ctx)$/;"	f	class:Byebug.Helpers
+locked_head	ext/byebug/locker.c	/^static locked_thread_t *locked_head = NULL;$/;"	v	file:
+locked_tail	ext/byebug/locker.c	/^static locked_thread_t *locked_tail = NULL;$/;"	v	file:
+locked_thread_t	ext/byebug/locker.c	/^typedef struct locked_thread_t$/;"	s	file:
+locked_thread_t	ext/byebug/locker.c	/^} locked_thread_t;$/;"	t	typeref:struct:locked_thread_t	file:
+locked_thread_t::next	ext/byebug/locker.c	/^  struct locked_thread_t *next;$/;"	m	struct:locked_thread_t	typeref:struct:locked_thread_t::locked_thread_t	file:	access:public
+locked_thread_t::thread	ext/byebug/locker.c	/^  VALUE thread;$/;"	m	struct:locked_thread_t	file:	access:public
+locker	ext/byebug/threads.c	/^static VALUE locker = Qnil;$/;"	v	file:
+locker.c	ext/byebug/locker.c	1;"	F
+lockfile	bin/bundle	/^  def lockfile$/;"	f
+lockfile_version	bin/bundle	/^  def lockfile_version$/;"	f
+login	docker/manager.rb	/^      def login$/;"	f	class:Docker.Manager
+login	docker/manager.rb	/^    def login$/;"	f	class:Docker.Manager
+lower_bound	lib/byebug/commands/list.rb	/^    def lower_bound(range)$/;"	f	class:Byebug.ListCommand
+mByebug	ext/byebug/byebug.c	/^static VALUE mByebug; \/* Ruby Byebug Module object *\/$/;"	v	file:
+manager.rb	docker/manager.rb	1;"	F
+mark	lib/byebug/frame.rb	/^    def mark$/;"	f	class:Byebug.Frame
+mark_breakpoint	ext/byebug/breakpoint.c	/^mark_breakpoint(breakpoint_t *breakpoint)$/;"	f	file:	signature:(breakpoint_t *breakpoint)
+match	lib/byebug/command.rb	/^      def match(input)$/;"	f	class:Byebug.Command
+match	lib/byebug/command_list.rb	/^    def match(input)$/;"	f	class:Byebug.CommandList
+matchers.rb	test/support/matchers.rb	1;"	F
+max_frames	lib/byebug/commands/finish.rb	/^    def max_frames$/;"	f	class:Byebug.FinishCommand
+max_initial_line	lib/byebug/source_file_formatter.rb	/^    def max_initial_line$/;"	f	class:Byebug.SourceFileFormatter
+max_line	lib/byebug/source_file_formatter.rb	/^    def max_line$/;"	f	class:Byebug.SourceFileFormatter
+method.rb	lib/byebug/commands/method.rb	1;"	F
+method_breakpoint	lib/byebug/commands/break.rb	/^    def method_breakpoint(location)$/;"	f	class:Byebug.BreakCommand.description
+method_test.rb	test/commands/method_test.rb	1;"	F
+mid	ext/byebug/byebug.h	/^    ID mid;$/;"	m	union:__anon5::__anon6	access:public
+minimal_program	test/support/utils.rb	/^    def minimal_program$/;"	f	class:Byebug.TestUtils
+minitest	bin/minitest	1;"	F
+minitest_runner.rb	test/minitest_runner.rb	1;"	F
+minitest_runner_test.rb	test/minitest_runner_test.rb	1;"	F
+modifier	lib/byebug/commands/continue.rb	/^    def modifier$/;"	f	class:Byebug.ContinueCommand
+move	lib/byebug/commands/list.rb	/^    def move(line, size, direction = "+")$/;"	f	class:Byebug.ListCommand
+msg	lib/byebug/helpers/eval.rb	/^      def msg(exception)$/;"	f	class:Byebug.Helpers.EvalHelper
+multiple_thread_eval	lib/byebug/helpers/eval.rb	/^      def multiple_thread_eval(expression)$/;"	f	class:Byebug.Helpers.EvalHelper
+mutex	test/support/remote_debugging_tests.rb	/^    def mutex$/;"	f	class:Byebug
+n_displays	lib/byebug/helpers/toggle.rb	/^      def n_displays$/;"	f	class:Byebug.Helpers.ToggleHelper
+n_lines	lib/byebug/helpers/file.rb	/^      def n_lines(filename)$/;"	f	class:Byebug.Helpers.FileHelper
+name	lib/byebug/errors.rb	/^    def name$/;"	f	class:Byebug.CommandNotFound
+navigate_to_frame	lib/byebug/helpers/frame.rb	/^      def navigate_to_frame(jump_no)$/;"	f	class:Byebug.Helpers.FrameHelper
+next	ext/byebug/locker.c	/^  struct locked_thread_t *next;$/;"	m	struct:locked_thread_t	typeref:struct:locked_thread_t::locked_thread_t	file:	access:public
+next.rb	lib/byebug/commands/next.rb	1;"	F
+next_test.rb	test/commands/next_test.rb	1;"	F
+next_thread	ext/byebug/threads.c	/^VALUE next_thread = Qnil;$/;"	v
+no_script?	lib/byebug/runner.rb	/^    def no_script?$/;"	f	class:Byebug.Runner
+non_existing_script?	lib/byebug/runner.rb	/^    def non_existing_script?$/;"	f	class:Byebug.Runner
+non_script_option?	lib/byebug/runner.rb	/^    def non_script_option?$/;"	f	class:Byebug.Runner
+non_stop_runner	test/rc_test.rb	/^    def non_stop_runner$/;"	f
+none	lib/byebug/breakpoint.rb	/^    def self.none?$/;"	F	class:Byebug.Breakpoint
+normalize	lib/byebug/helpers/file.rb	/^      def normalize(filename)$/;"	f	class:Byebug.Helpers.FileHelper
+numbers	test/processors/command_processor_test.rb	/^            def numbers$/;"	f	class:ProcessorEvaluationAndThreadsTest.program.Byebug
+on_change	lib/byebug/commands/tracevar.rb	/^    def on_change(name, value, stop)$/;"	f	class:Byebug.TracevarCommand
+open_debug_inspector	ext/byebug/context.c	/^open_debug_inspector(struct call_with_inspection_data *cwi)$/;"	f	file:	signature:(struct call_with_inspection_data *cwi)
+open_debug_inspector_ensure	ext/byebug/context.c	/^open_debug_inspector_ensure(VALUE v)$/;"	f	file:	signature:(VALUE v)
+open_debug_inspector_i	ext/byebug/context.c	/^open_debug_inspector_i(const rb_debug_inspector_t *inspector, void *data)$/;"	f	file:	signature:(const rb_debug_inspector_t *inspector, void *data)
+option_parser	lib/byebug/runner.rb	/^    def option_parser$/;"	f	class:Byebug.Runner
+option_setter.rb	lib/byebug/option_setter.rb	1;"	F
+or	lib/byebug/commands/method.rb	/^        class or module specified as argument.$/;"	c	class:Byebug.MethodCommand.description
+out_of_bounds?	lib/byebug/helpers/frame.rb	/^      def out_of_bounds?(pos)$/;"	f	class:Byebug.Helpers.FrameHelper
+parse.rb	lib/byebug/helpers/parse.rb	1;"	F
+parse_host_and_port	lib/byebug/remote.rb	/^    def parse_host_and_port(host_port_spec)$/;"	f	class:Byebug
+parse_range	lib/byebug/commands/list.rb	/^    def parse_range(input)$/;"	f	class:Byebug.ListCommand
+parse_steps	lib/byebug/helpers/parse.rb	/^      def parse_steps(str, cmd)$/;"	f	class:Byebug.Helpers.ParseHelper
+parts	lib/byebug/printers/base.rb	/^      def parts(path)$/;"	f	class:Byebug.Printers
+path.rb	lib/byebug/helpers/path.rb	1;"	F
+plain.rb	lib/byebug/printers/plain.rb	1;"	F
+plain_test.rb	test/printers/plain_test.rb	1;"	F
+pop	lib/byebug/history.rb	/^    def pop$/;"	f	class:Byebug
+pos	ext/byebug/byebug.h	/^  } pos;$/;"	m	struct:__anon5	typeref:union:__anon5::__anon6	access:public
+post_mortem	ext/byebug/byebug.c	/^static VALUE post_mortem = Qfalse;$/;"	v	file:
+post_mortem	lib/byebug/option_setter.rb	/^    def post_mortem$/;"	f
+post_mortem.rb	lib/byebug/settings/post_mortem.rb	1;"	F
+post_mortem_processor.rb	lib/byebug/processors/post_mortem_processor.rb	1;"	F
+post_mortem_test.rb	test/post_mortem_test.rb	1;"	F
+potential_line	lib/byebug/breakpoint.rb	/^    def self.potential_line?(filename, lineno)$/;"	F	class:Byebug.Breakpoint
+potential_lines	lib/byebug/breakpoint.rb	/^    def self.potential_lines(filename)$/;"	F	class:Byebug.Breakpoint
+potential_lines_with_trace_points	lib/byebug/breakpoint.rb	/^    def self.potential_lines_with_trace_points(iseq, lines)$/;"	F	class:Byebug.Breakpoint
+potential_lines_without_trace_points	lib/byebug/breakpoint.rb	/^    def self.potential_lines_without_trace_points(iseq, lines)$/;"	F	class:Byebug.Breakpoint
+prefix_and_default	lib/byebug/frame.rb	/^    def prefix_and_default(arg_type)$/;"	f	class:Byebug.Frame
+prepare	lib/byebug/interfaces/test_interface.rb	/^    def prepare(message)$/;"	f	class:Byebug.TestInterface
+prepare_for_regexp	test/support/utils.rb	/^    def prepare_for_regexp(output_str)$/;"	f	class:Byebug.TestUtils
+prepare_input	lib/byebug/interface.rb	/^    def prepare_input(prompt)$/;"	f	class:Byebug.Interface
+prepend_byebug_bin	lib/byebug/commands/restart.rb	/^    def prepend_byebug_bin(cmd)$/;"	f	class:Byebug.RestartCommand
+prepend_ruby_bin	lib/byebug/commands/restart.rb	/^    def prepend_ruby_bin(cmd)$/;"	f	class:Byebug.RestartCommand
+prettify	lib/byebug/helpers/string.rb	/^      def prettify(str)$/;"	f	class:Byebug.Helpers.StringHelper
+print	lib/byebug/interface.rb	/^    def print(message)$/;"	f	class:Byebug.Interface
+print	lib/byebug/interfaces/remote_interface.rb	/^    def print(message)$/;"	f	class:Byebug.RemoteInterface
+print	lib/byebug/interfaces/test_interface.rb	/^    def print(message)$/;"	f	class:Byebug.TestInterface
+print	lib/byebug/printers/plain.rb	/^      def print(path, args = {})$/;"	f	class:Byebug.Printers.Plain
+print_backtrace	lib/byebug/commands/where.rb	/^    def print_backtrace$/;"	f	class:Byebug.WhereCommand
+print_collection	lib/byebug/printers/plain.rb	/^      def print_collection(path, collection, &block)$/;"	f	class:Byebug.Printers.Plain
+print_display_expressions	lib/byebug/commands/display.rb	/^    def print_display_expressions$/;"	f	class:Byebug.DisplayCommand
+print_error	lib/byebug/runner.rb	/^    def print_error(msg)$/;"	f	class:Byebug.Runner
+print_variables	lib/byebug/printers/plain.rb	/^      def print_variables(variables, *_unused)$/;"	f	class:Byebug.Printers.Plain
+printer	lib/byebug/processors/command_processor.rb	/^    def printer$/;"	f	class:Byebug.CommandProcessor
+printer	test/printers/plain_test.rb	/^    def printer$/;"	f	class:Byebug.PrintersPlainTest
+printer_stub	test/support/assertions.rb	/^    def printer_stub(method_name)$/;"	f	class:Minitest
+proceed!	lib/byebug/processors/command_processor.rb	/^    def proceed!$/;"	f	class:Byebug.CommandProcessor
+process_commands	lib/byebug/processors/command_processor.rb	/^    def process_commands$/;"	f	class:Byebug.CommandProcessor
+process_rc_file	test/processors/script_processor_test.rb	/^    def process_rc_file(content)$/;"	f	class:Byebug.ScriptProcessorTest
+processor	lib/byebug/context.rb	/^      def processor$/;"	f	class:Byebug.Context
+processor	lib/byebug/context.rb	/^    def processor$/;"	f	class:Byebug
+program	lib/byebug/runner.rb	/^    def program$/;"	f	class:Byebug.Runner
+program	test/commands/break_test.rb	/^    def program$/;"	f	class:BreakAtEmptyMethodsTest
+program	test/commands/break_test.rb	/^    def program$/;"	f	class:BreakAtLinesTest
+program	test/commands/break_test.rb	/^    def program$/;"	f	class:BreakWithByebugKeywordAtBlockEndTest
+program	test/commands/break_test.rb	/^    def program$/;"	f	class:BreakWithByebugKeywordAtClassDefinitionEndTest
+program	test/commands/break_test.rb	/^    def program$/;"	f	class:BreakWithByebugKeywordAtMethodEndTest
+program	test/commands/break_test.rb	/^    def program$/;"	f	class:Byebug.BreakAtMethodsTest
+program	test/commands/condition_test.rb	/^    def program$/;"	f	class:Byebug.ConditionTest
+program	test/commands/continue_test.rb	/^    def program$/;"	f	class:Byebug.ContinueTest
+program	test/commands/continue_test.rb	/^    def program$/;"	f	class:ContinueUnconditionallyWithByebugCallsTest
+program	test/commands/debug_test.rb	/^    def program$/;"	f	class:Byebug.SubdebuggersTest
+program	test/commands/delete_test.rb	/^    def program$/;"	f	class:Byebug.DeleteTest
+program	test/commands/disable_test.rb	/^    def program$/;"	f	class:Byebug.DisableTest
+program	test/commands/display_test.rb	/^    def program$/;"	f	class:Byebug.DisplayTest
+program	test/commands/down_test.rb	/^    def program$/;"	f	class:Byebug.DownTest
+program	test/commands/enable_test.rb	/^    def program$/;"	f	class:Byebug.EnableTest
+program	test/commands/finish_test.rb	/^    def program$/;"	f	class:Byebug.FinishAfterReturnTest
+program	test/commands/finish_test.rb	/^    def program$/;"	f	class:FinishBeforeReturnTest
+program	test/commands/finish_test.rb	/^    def program$/;"	f	class:FinishInsideAutoloadedFilesTest
+program	test/commands/frame_test.rb	/^    def program$/;"	f	class:Byebug.FrameTest
+program	test/commands/history_test.rb	/^      def program$/;"	f	class:Byebug.HistoryTest
+program	test/commands/info_test.rb	/^    def program$/;"	f	class:Byebug.InfoTest
+program	test/commands/info_test.rb	/^    def program$/;"	f	class:InfoFileTest
+program	test/commands/interrupt_test.rb	/^    def program$/;"	f	class:Byebug.InterruptTest
+program	test/commands/irb_test.rb	/^    def program$/;"	f	class:Byebug.IrbTest
+program	test/commands/kill_test.rb	/^    def program$/;"	f	class:Byebug.KillTest
+program	test/commands/list_test.rb	/^    def program$/;"	f	class:Byebug.ListTest
+program	test/commands/method_test.rb	/^    def program$/;"	f	class:Byebug.MethodTest
+program	test/commands/next_test.rb	/^    def program$/;"	f	class:Byebug.BasicNextTest
+program	test/commands/next_test.rb	/^    def program$/;"	f	class:NextAndDefineMethodTest
+program	test/commands/next_test.rb	/^    def program$/;"	f	class:NextBacktracesTest
+program	test/commands/next_test.rb	/^    def program$/;"	f	class:NextGoingUpFramesTest
+program	test/commands/next_test.rb	/^    def program$/;"	f	class:NextRescueTest
+program	test/commands/next_test.rb	/^    def program$/;"	f	class:NextWhenReturnInsideLoopInsideInitializeTest
+program	test/commands/next_test.rb	/^    def program$/;"	f	class:TopLevelBlockEventsTest
+program	test/commands/pry_test.rb	/^    def program$/;"	f	class:Byebug.PryTest
+program	test/commands/save_test.rb	/^    def program$/;"	f	class:Byebug.SaveTest
+program	test/commands/set_test.rb	/^    def program$/;"	f	class:Byebug.SetTest
+program	test/commands/skip_test.rb	/^    def program$/;"	f	class:Byebug.SkipTest
+program	test/commands/source_test.rb	/^    def program$/;"	f	class:Byebug.SourceTest
+program	test/commands/step_test.rb	/^    def program$/;"	f	class:Byebug.BasicSteppingTest
+program	test/commands/step_test.rb	/^    def program$/;"	f	class:MoreThanOneStepTest
+program	test/commands/step_test.rb	/^    def program$/;"	f	class:SteppingBacktracesTest
+program	test/commands/thread_test.rb	/^    def program$/;"	f	class:Byebug.ThreadTest
+program	test/commands/tracevar_test.rb	/^    def program$/;"	f	class:Byebug.TracevarTest
+program	test/commands/undisplay_test.rb	/^    def program$/;"	f	class:Byebug.UndisplayTest
+program	test/commands/up_test.rb	/^    def program$/;"	f	class:Byebug.UpTest
+program	test/commands/var_test.rb	/^    def program$/;"	f	class:Byebug.VarTest
+program	test/commands/where_test.rb	/^    def program$/;"	f	class:Byebug.WhereStandardTest
+program	test/post_mortem_test.rb	/^    def program$/;"	f	class:Byebug.PostMortemTest
+program	test/processors/command_processor_test.rb	/^    def program$/;"	f	class:Byebug.ProcessorBaseTest
+program	test/processors/command_processor_test.rb	/^    def program$/;"	f	class:ProcessorAutocommandsTest
+program	test/processors/command_processor_test.rb	/^    def program$/;"	f	class:ProcessorEvaluationAndBreakpointsTest
+program	test/processors/command_processor_test.rb	/^    def program$/;"	f	class:ProcessorEvaluationAndThreadsTest
+program	test/processors/command_processor_test.rb	/^    def program$/;"	f	class:ProcessorUnknownInputTest
+program	test/remote_debugging_test.rb	/^    def program$/;"	f	class:Byebug.RemoteDebuggingTest
+program	test/remote_shortcut_test.rb	/^    def program$/;"	f	class:Byebug.RemoteShortcutTest
+program.rb	lib/byebug/commands/info/program.rb	1;"	F
+program_raising	test/commands/info_test.rb	/^    def program_raising$/;"	f	class:InfoCrashedTest
+program_with_two_breakpoints	test/remote_debugging_test.rb	/^    def program_with_two_breakpoints$/;"	f
+prompt	lib/byebug/processors/command_processor.rb	/^    def prompt$/;"	f	class:Byebug.CommandProcessor
+prompt	lib/byebug/processors/control_processor.rb	/^    def prompt$/;"	f	class:Byebug.ControlProcessor
+prompt	lib/byebug/processors/post_mortem_processor.rb	/^    def prompt$/;"	f	class:Byebug.PostMortemProcessor
+prompt	lib/byebug/processors/script_processor.rb	/^    def prompt$/;"	f	class:Byebug.ScriptProcessor
+pry.rb	lib/byebug/commands/pry.rb	1;"	F
+pry_test.rb	test/commands/pry_test.rb	1;"	F
+push	docker/manager.rb	/^    def push$/;"	f	class:Docker.Manager
+push	lib/byebug/history.rb	/^    def push(cmd)$/;"	f	class:Byebug
+push_all	docker/manager.rb	/^      def push_all$/;"	f	class:Docker.Manager
+push_default	docker/manager.rb	/^      def push_default$/;"	f	class:Docker.Manager
+puts	lib/byebug/interface.rb	/^    def puts(message)$/;"	f	class:Byebug.Interface
+puts	lib/byebug/interfaces/remote_interface.rb	/^    def puts(message)$/;"	f	class:Byebug.RemoteInterface
+puts	lib/byebug/interfaces/test_interface.rb	/^    def puts(message)$/;"	f	class:Byebug.TestInterface
+quit	lib/byebug/option_setter.rb	/^    def quit$/;"	f
+quit.rb	lib/byebug/commands/quit.rb	1;"	F
+quit_test.rb	test/commands/quit_test.rb	1;"	F
+raise_event	ext/byebug/byebug.c	/^raise_event(VALUE trace_point, void *data)$/;"	f	file:	signature:(VALUE trace_point, void *data)
+raised_exception	ext/byebug/byebug.c	/^static VALUE raised_exception = Qnil;$/;"	v	file:
+rake	bin/rake	1;"	F
+range	lib/byebug/commands/list.rb	/^    def range(input)$/;"	f	class:Byebug.ListCommand
+range_around	lib/byebug/source_file_formatter.rb	/^    def range_around(center)$/;"	f	class:Byebug.SourceFileFormatter
+range_from	lib/byebug/source_file_formatter.rb	/^    def range_from(min)$/;"	f	class:Byebug.SourceFileFormatter
+raw_call_event	ext/byebug/byebug.c	/^raw_call_event(VALUE trace_point, void *data)$/;"	f	file:	signature:(VALUE trace_point, void *data)
+raw_return_event	ext/byebug/byebug.c	/^raw_return_event(VALUE trace_point, void *data)$/;"	f	file:	signature:(VALUE trace_point, void *data)
+rc	lib/byebug/option_setter.rb	/^    def rc$/;"	f
+rc_dirs	lib/byebug/core.rb	/^  def rc_dirs$/;"	f
+rc_positive_test	test/rc_test.rb	/^    def rc_positive_test(flag)$/;"	f
+rc_test.rb	test/rc_test.rb	1;"	F
+read_command	lib/byebug/interface.rb	/^    def read_command(prompt)$/;"	f	class:Byebug.Interface
+read_command	lib/byebug/interfaces/remote_interface.rb	/^    def read_command(prompt)$/;"	f	class:Byebug.RemoteInterface
+read_command	lib/byebug/interfaces/script_interface.rb	/^    def read_command(prompt)$/;"	f	class:Byebug.ScriptInterface
+read_command	lib/byebug/interfaces/test_interface.rb	/^    def read_command(prompt)$/;"	f	class:Byebug.TestInterface
+read_file	lib/byebug/interface.rb	/^    def read_file(filename)$/;"	f	class:Byebug.Interface
+read_input	lib/byebug/interface.rb	/^    def read_input(prompt, save_hist = true)$/;"	f	class:Byebug.Interface
+readline	lib/byebug/interfaces/local_interface.rb	/^    def readline(prompt)$/;"	f	class:Byebug.LocalInterface
+readline	lib/byebug/interfaces/remote_interface.rb	/^    def readline(prompt)$/;"	f	class:Byebug.RemoteInterface
+readline	lib/byebug/interfaces/script_interface.rb	/^    def readline(*)$/;"	f	class:Byebug.ScriptInterface
+readline	lib/byebug/interfaces/test_interface.rb	/^    def readline(prompt)$/;"	f	class:Byebug.TestInterface
+readline	test/interface_test.rb	/^    def readline(_prompt)$/;"	f	class:Byebug.SpecificInterface
+readme_path	test/commands/edit_test.rb	/^    def readme_path$/;"	f
+real_executable?	lib/byebug/helpers/bin.rb	/^      def real_executable?(file)$/;"	f	class:Byebug.Helpers.BinHelper
+reflection.rb	lib/byebug/helpers/reflection.rb	1;"	F
+refute_calls	test/support/assertions.rb	/^    def refute_calls(object, method, *expected_args, &block)$/;"	f	class:Minitest.Assertions
+refute_includes_in_order	test/support/assertions.rb	/^    def refute_includes_in_order(given, original, msg = nil)$/;"	f	class:Minitest.Assertions
+regexp	lib/byebug/commands/break.rb	/^    def self.regexp$/;"	F	class:Byebug.BreakCommand
+regexp	lib/byebug/commands/catch.rb	/^    def self.regexp$/;"	F	class:Byebug.CatchCommand
+regexp	lib/byebug/commands/condition.rb	/^    def self.regexp$/;"	F	class:Byebug.ConditionCommand
+regexp	lib/byebug/commands/continue.rb	/^    def self.regexp$/;"	F	class:Byebug.ContinueCommand
+regexp	lib/byebug/commands/debug.rb	/^    def self.regexp$/;"	F	class:Byebug.DebugCommand
+regexp	lib/byebug/commands/delete.rb	/^    def self.regexp$/;"	F	class:Byebug.DeleteCommand
+regexp	lib/byebug/commands/disable.rb	/^    def self.regexp$/;"	F	class:Byebug.DisableCommand
+regexp	lib/byebug/commands/disable/breakpoints.rb	/^      def self.regexp$/;"	F	class:Byebug.DisableCommand.BreakpointsCommand
+regexp	lib/byebug/commands/disable/display.rb	/^      def self.regexp$/;"	F	class:Byebug.DisableCommand.DisplayCommand
+regexp	lib/byebug/commands/display.rb	/^    def self.regexp$/;"	F	class:Byebug.DisplayCommand
+regexp	lib/byebug/commands/down.rb	/^    def self.regexp$/;"	F	class:Byebug.DownCommand
+regexp	lib/byebug/commands/edit.rb	/^    def self.regexp$/;"	F	class:Byebug.EditCommand
+regexp	lib/byebug/commands/enable.rb	/^    def self.regexp$/;"	F	class:Byebug.EnableCommand
+regexp	lib/byebug/commands/enable/breakpoints.rb	/^      def self.regexp$/;"	F	class:Byebug.EnableCommand.BreakpointsCommand
+regexp	lib/byebug/commands/enable/display.rb	/^      def self.regexp$/;"	F	class:Byebug.EnableCommand.DisplayCommand
+regexp	lib/byebug/commands/finish.rb	/^    def self.regexp$/;"	F	class:Byebug.FinishCommand
+regexp	lib/byebug/commands/frame.rb	/^    def self.regexp$/;"	F	class:Byebug.FrameCommand
+regexp	lib/byebug/commands/help.rb	/^    def self.regexp$/;"	F	class:Byebug.HelpCommand
+regexp	lib/byebug/commands/history.rb	/^    def self.regexp$/;"	F	class:Byebug.HistoryCommand
+regexp	lib/byebug/commands/info.rb	/^    def self.regexp$/;"	F	class:Byebug.InfoCommand
+regexp	lib/byebug/commands/info/breakpoints.rb	/^      def self.regexp$/;"	F	class:Byebug.InfoCommand.BreakpointsCommand
+regexp	lib/byebug/commands/info/display.rb	/^      def self.regexp$/;"	F	class:Byebug.InfoCommand.DisplayCommand
+regexp	lib/byebug/commands/info/file.rb	/^      def self.regexp$/;"	F	class:Byebug.InfoCommand.FileCommand
+regexp	lib/byebug/commands/info/line.rb	/^      def self.regexp$/;"	F	class:Byebug.InfoCommand.LineCommand
+regexp	lib/byebug/commands/info/program.rb	/^      def self.regexp$/;"	F	class:Byebug.InfoCommand.ProgramCommand
+regexp	lib/byebug/commands/interrupt.rb	/^    def self.regexp$/;"	F	class:Byebug.InterruptCommand
+regexp	lib/byebug/commands/irb.rb	/^    def self.regexp$/;"	F	class:Byebug.IrbCommand
+regexp	lib/byebug/commands/kill.rb	/^    def self.regexp$/;"	F	class:Byebug.KillCommand
+regexp	lib/byebug/commands/list.rb	/^    def self.regexp$/;"	F	class:Byebug.ListCommand
+regexp	lib/byebug/commands/method.rb	/^    def self.regexp$/;"	F	class:Byebug.MethodCommand
+regexp	lib/byebug/commands/next.rb	/^    def self.regexp$/;"	F	class:Byebug.NextCommand
+regexp	lib/byebug/commands/pry.rb	/^    def self.regexp$/;"	F	class:Byebug.PryCommand
+regexp	lib/byebug/commands/quit.rb	/^    def self.regexp$/;"	F	class:Byebug.QuitCommand
+regexp	lib/byebug/commands/restart.rb	/^    def self.regexp$/;"	F	class:Byebug.RestartCommand
+regexp	lib/byebug/commands/save.rb	/^    def self.regexp$/;"	F	class:Byebug.SaveCommand
+regexp	lib/byebug/commands/set.rb	/^    def self.regexp$/;"	F	class:Byebug.SetCommand
+regexp	lib/byebug/commands/show.rb	/^    def self.regexp$/;"	F	class:Byebug.ShowCommand
+regexp	lib/byebug/commands/skip.rb	/^    def self.regexp$/;"	F	class:Byebug
+regexp	lib/byebug/commands/source.rb	/^    def self.regexp$/;"	F	class:Byebug.SourceCommand
+regexp	lib/byebug/commands/step.rb	/^    def self.regexp$/;"	F	class:Byebug.StepCommand
+regexp	lib/byebug/commands/thread.rb	/^    def self.regexp$/;"	F	class:Byebug.ThreadCommand
+regexp	lib/byebug/commands/thread/current.rb	/^      def self.regexp$/;"	F	class:Byebug.ThreadCommand.CurrentCommand
+regexp	lib/byebug/commands/thread/list.rb	/^      def self.regexp$/;"	F	class:Byebug.ThreadCommand.ListCommand
+regexp	lib/byebug/commands/thread/resume.rb	/^      def self.regexp$/;"	F	class:Byebug.ThreadCommand.ResumeCommand
+regexp	lib/byebug/commands/thread/stop.rb	/^      def self.regexp$/;"	F	class:Byebug.ThreadCommand.StopCommand
+regexp	lib/byebug/commands/thread/switch.rb	/^      def self.regexp$/;"	F	class:Byebug.ThreadCommand.SwitchCommand
+regexp	lib/byebug/commands/tracevar.rb	/^    def self.regexp$/;"	F	class:Byebug.TracevarCommand
+regexp	lib/byebug/commands/undisplay.rb	/^    def self.regexp$/;"	F	class:Byebug.UndisplayCommand
+regexp	lib/byebug/commands/untracevar.rb	/^    def self.regexp$/;"	F	class:Byebug.UntracevarCommand
+regexp	lib/byebug/commands/up.rb	/^    def self.regexp$/;"	F	class:Byebug.UpCommand
+regexp	lib/byebug/commands/var.rb	/^    def self.regexp$/;"	F	class:Byebug.VarCommand
+regexp	lib/byebug/commands/var/all.rb	/^      def self.regexp$/;"	F	class:Byebug.VarCommand.AllCommand
+regexp	lib/byebug/commands/var/args.rb	/^      def self.regexp$/;"	F	class:Byebug.VarCommand.ArgsCommand
+regexp	lib/byebug/commands/var/const.rb	/^      def self.regexp$/;"	F	class:Byebug.VarCommand.ConstCommand
+regexp	lib/byebug/commands/var/global.rb	/^      def self.regexp$/;"	F	class:Byebug.VarCommand.GlobalCommand
+regexp	lib/byebug/commands/var/instance.rb	/^      def self.regexp$/;"	F	class:Byebug.VarCommand.InstanceCommand
+regexp	lib/byebug/commands/var/local.rb	/^      def self.regexp$/;"	F	class:Byebug.VarCommand.LocalCommand
+regexp	lib/byebug/commands/where.rb	/^    def self.regexp$/;"	F	class:Byebug.WhereCommand
+register_tracepoints	ext/byebug/byebug.c	/^register_tracepoints(VALUE self)$/;"	f	file:	signature:(VALUE self)
+release_info	docker/manager.rb	/^      def release_info$/;"	f	class:Docker.Manager
+release_info	docker/manager.rb	/^    def release_info$/;"	f	class:Docker
+release_lock	ext/byebug/byebug.h	/^extern void release_lock(void);$/;"	p	signature:(void)
+release_lock	ext/byebug/threads.c	/^release_lock(void)$/;"	f	signature:(void)
+releases_url	docker/manager.rb	/^      def releases_url$/;"	f	class:Docker.Manager
+remote	lib/byebug/option_setter.rb	/^    def remote$/;"	f
+remote.rb	lib/byebug/remote.rb	1;"	F
+remote=	lib/byebug/runner.rb	/^    def remote=(host_and_port)$/;"	f	class:Byebug.Runner
+remote_byebug	lib/byebug/attacher.rb	/^  def remote_byebug(host = "localhost", port = nil)$/;"	f	class:Kernel
+remote_debug	test/support/remote_debugging_tests.rb	/^    def remote_debug(*commands)$/;"	f	class:Byebug.RemoteDebuggingTests
+remote_debug_and_connect	test/support/remote_debugging_tests.rb	/^    def remote_debug_and_connect(*commands)$/;"	f	class:Byebug.RemoteDebuggingTests
+remote_debug_connect_and_interrupt	test/support/remote_debugging_tests.rb	/^    def remote_debug_connect_and_interrupt(*commands)$/;"	f	class:Byebug.RemoteDebuggingTests
+remote_debugging_test.rb	test/remote_debugging_test.rb	1;"	F
+remote_debugging_tests.rb	test/support/remote_debugging_tests.rb	1;"	F
+remote_interface.rb	lib/byebug/interfaces/remote_interface.rb	1;"	F
+remote_shortcut_test.rb	test/remote_shortcut_test.rb	1;"	F
+remove	lib/byebug/breakpoint.rb	/^    def self.remove(id)$/;"	F	class:Byebug.Breakpoint
+remove	lib/byebug/commands/catch.rb	/^    def remove(exception)$/;"	f	class:Byebug.CatchCommand
+repl	lib/byebug/processors/command_processor.rb	/^    def repl$/;"	f	class:Byebug.CommandProcessor
+repl	lib/byebug/processors/script_processor.rb	/^    def repl$/;"	f	class:Byebug.ScriptProcessor
+replace_build_percentage_string_line_and_list_it	test/commands/list_test.rb	/^    def replace_build_percentage_string_line_and_list_it$/;"	f
+require_flag	lib/byebug/option_setter.rb	/^    def require_flag$/;"	f
+reset_attributes	lib/byebug/commands/skip.rb	/^    def reset_attributes$/;"	f	class:Byebug
+restart.rb	lib/byebug/commands/restart.rb	1;"	F
+restart_test.rb	test/commands/restart_test.rb	1;"	F
+restore	lib/byebug/history.rb	/^    def restore$/;"	f	class:Byebug.History
+restore_autolist	lib/byebug/commands/skip.rb	/^      def restore_autolist$/;"	f	class:Byebug.SkipCommand
+resume.rb	lib/byebug/commands/thread/resume.rb	1;"	F
+return_event	ext/byebug/byebug.c	/^return_event(VALUE trace_point, void *data)$/;"	f	file:	signature:(VALUE trace_point, void *data)
+root_path	lib/byebug/helpers/path.rb	/^      def root_path$/;"	f	class:Byebug.Helpers.PathHelper
+rubocop	bin/rubocop	1;"	F
+ruby_args	lib/byebug/frame.rb	/^    def ruby_args$/;"	f	class:Byebug.Frame
+ruby_bin	test/commands/restart_test.rb	/^    def ruby_bin$/;"	f
+run	docker/manager.rb	/^      def run(*command)$/;"	f	class:Docker.Manager
+run	docker/manager.rb	/^    def run(*command)$/;"	f	class:Docker
+run	lib/byebug/runner.rb	/^    def run$/;"	f	class:Byebug.Runner
+run	tasks/linter.rb	/^  def run$/;"	f	class:LinterMixin
+run	test/minitest_runner.rb	/^    def run$/;"	f	class:Byebug.MinitestRunner
+run_auto_cmds	lib/byebug/processors/command_processor.rb	/^    def run_auto_cmds(run_level)$/;"	f	class:Byebug
+run_byebug	test/support/utils.rb	/^    def run_byebug(*args, input: "")$/;"	f	class:Byebug.TestUtils
+run_cmd	lib/byebug/processors/command_processor.rb	/^    def run_cmd(input)$/;"	f	class:Byebug
+run_init_script	lib/byebug/core.rb	/^  def run_init_script$/;"	f	class:Byebug
+run_minitest_runner	test/minitest_runner_test.rb	/^    def run_minitest_runner(*args)$/;"	f	class:Byebug.MinitestRunnerTest
+run_program	test/support/utils.rb	/^    def run_program(cmd, input = "")$/;"	f	class:Byebug.TestUtils
+run_rc_file	lib/byebug/core.rb	/^  def run_rc_file(rc_file)$/;"	f
+runnables	test/minitest_runner.rb	/^    def runnables$/;"	f	class:Byebug
+runner.rb	lib/byebug/runner.rb	1;"	F
+runner_against_program_with_byebug_call_test.rb	test/runner_against_program_with_byebug_call_test.rb	1;"	F
+runner_against_valid_program_test.rb	test/runner_against_valid_program_test.rb	1;"	F
+runner_without_target_program_test.rb	test/runner_without_target_program_test.rb	1;"	F
+safe_eval	lib/byebug/helpers/eval.rb	/^      def safe_eval(str, binding)$/;"	f	class:Byebug.Helpers.EvalHelper
+safe_inspect	lib/byebug/helpers/eval.rb	/^      def safe_inspect(var)$/;"	f	class:Byebug.Helpers.EvalHelper
+safe_to_s	lib/byebug/helpers/eval.rb	/^      def safe_to_s(var)$/;"	f	class:Byebug.Helpers.EvalHelper
+safely	lib/byebug/processors/command_processor.rb	/^    def safely$/;"	f	class:Byebug
+save	lib/byebug/history.rb	/^    def save$/;"	f	class:Byebug.History
+save.rb	lib/byebug/commands/save.rb	1;"	F
+save_breakpoints	lib/byebug/commands/save.rb	/^    def save_breakpoints(file)$/;"	f	class:Byebug.SaveCommand
+save_catchpoints	lib/byebug/commands/save.rb	/^    def save_catchpoints(file)$/;"	f	class:Byebug.SaveCommand
+save_displays	lib/byebug/commands/save.rb	/^    def save_displays(file)$/;"	f	class:Byebug.SaveCommand
+save_settings	lib/byebug/commands/save.rb	/^    def save_settings(file)$/;"	f	class:Byebug.SaveCommand
+save_test.rb	test/commands/save_test.rb	1;"	F
+savefile.rb	lib/byebug/settings/savefile.rb	1;"	F
+script_interface.rb	lib/byebug/interfaces/script_interface.rb	1;"	F
+script_interface_test.rb	test/interfaces/script_interface_test.rb	1;"	F
+script_processor.rb	lib/byebug/processors/script_processor.rb	1;"	F
+script_processor_test.rb	test/processors/script_processor_test.rb	1;"	F
+search_paths	lib/byebug/helpers/bin.rb	/^      def search_paths$/;"	f	class:Byebug.Helpers.BinHelper
+select_breakpoints	lib/byebug/helpers/toggle.rb	/^      def select_breakpoints(is_enable, args)$/;"	f	class:Byebug.Helpers.ToggleHelper
+separate_thread_eval	lib/byebug/helpers/eval.rb	/^      def separate_thread_eval(expression)$/;"	f	class:Byebug.Helpers.EvalHelper
+server	lib/byebug/remote.rb	/^    def server$/;"	f	class:Byebug
+server.rb	lib/byebug/remote/server.rb	1;"	F
+set.rb	lib/byebug/commands/set.rb	1;"	F
+set_test.rb	test/commands/set_test.rb	1;"	F
+setting.rb	lib/byebug/setting.rb	1;"	F
+settings	lib/byebug/setting.rb	/^      def settings$/;"	f	class:Byebug.Setting
+setup	lib/byebug/option_setter.rb	/^    def setup$/;"	f	class:Byebug.OptionSetter
+setup	test/commands/help_test.rb	/^    def setup$/;"	f	class:Byebug.HelpAloneTest
+setup	test/commands/source_test.rb	/^    def setup$/;"	f	class:Byebug
+setup	test/commands/where_test.rb	/^    def setup$/;"	f	class:WhereWithDeeplyNestedPathsTest
+setup	test/interface_test.rb	/^    def setup$/;"	f	class:Byebug.InterfaceTest
+setup	test/rc_test.rb	/^    def setup$/;"	f	class:Byebug.RcTest
+setup	test/runner_against_program_with_byebug_call_test.rb	/^    def setup$/;"	f	class:Byebug.RunnerAgainstProgramWithByebugCallTest
+setup	test/runner_against_valid_program_test.rb	/^    def setup$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+setup	test/support/test_case.rb	/^    def setup$/;"	f	class:Byebug.TestCase
+setup.sh	bin/setup.sh	1;"	F
+setup_autolist	lib/byebug/commands/skip.rb	/^      def setup_autolist(value)$/;"	f	class:Byebug.SkipCommand
+shell_out_env	test/support/utils.rb	/^    def shell_out_env(simplecov: true)$/;"	f	class:Byebug.TestUtils
+short_description	lib/byebug/commands/break.rb	/^    def self.short_description$/;"	F	class:Byebug.BreakCommand.description
+short_description	lib/byebug/commands/catch.rb	/^    def self.short_description$/;"	F	class:Byebug.CatchCommand
+short_description	lib/byebug/commands/condition.rb	/^    def self.short_description$/;"	F	class:Byebug.ConditionCommand
+short_description	lib/byebug/commands/continue.rb	/^    def self.short_description$/;"	F	class:Byebug.ContinueCommand
+short_description	lib/byebug/commands/debug.rb	/^    def self.short_description$/;"	F	class:Byebug.DebugCommand
+short_description	lib/byebug/commands/delete.rb	/^    def self.short_description$/;"	F	class:Byebug.DeleteCommand
+short_description	lib/byebug/commands/disable.rb	/^    def self.short_description$/;"	F	class:Byebug.DisableCommand
+short_description	lib/byebug/commands/disable/breakpoints.rb	/^      def self.short_description$/;"	F	class:Byebug.DisableCommand.BreakpointsCommand
+short_description	lib/byebug/commands/disable/display.rb	/^      def self.short_description$/;"	F	class:Byebug.DisableCommand.DisplayCommand
+short_description	lib/byebug/commands/display.rb	/^    def self.short_description$/;"	F	class:Byebug.DisplayCommand
+short_description	lib/byebug/commands/down.rb	/^    def self.short_description$/;"	F	class:Byebug.DownCommand
+short_description	lib/byebug/commands/edit.rb	/^    def self.short_description$/;"	F	class:Byebug.EditCommand
+short_description	lib/byebug/commands/enable.rb	/^    def self.short_description$/;"	F	class:Byebug.EnableCommand
+short_description	lib/byebug/commands/enable/breakpoints.rb	/^      def self.short_description$/;"	F	class:Byebug.EnableCommand.BreakpointsCommand
+short_description	lib/byebug/commands/enable/display.rb	/^      def self.short_description$/;"	F	class:Byebug.EnableCommand.DisplayCommand
+short_description	lib/byebug/commands/finish.rb	/^    def self.short_description$/;"	F	class:Byebug.FinishCommand
+short_description	lib/byebug/commands/frame.rb	/^    def self.short_description$/;"	F	class:Byebug.FrameCommand
+short_description	lib/byebug/commands/help.rb	/^    def self.short_description$/;"	F	class:Byebug.HelpCommand
+short_description	lib/byebug/commands/history.rb	/^    def self.short_description$/;"	F	class:Byebug.HistoryCommand
+short_description	lib/byebug/commands/info.rb	/^    def self.short_description$/;"	F	class:Byebug.InfoCommand
+short_description	lib/byebug/commands/info/breakpoints.rb	/^      def self.short_description$/;"	F	class:Byebug.InfoCommand.BreakpointsCommand
+short_description	lib/byebug/commands/info/display.rb	/^      def self.short_description$/;"	F	class:Byebug.InfoCommand.DisplayCommand
+short_description	lib/byebug/commands/info/file.rb	/^      def self.short_description$/;"	F	class:Byebug.InfoCommand.FileCommand
+short_description	lib/byebug/commands/info/line.rb	/^      def self.short_description$/;"	F	class:Byebug.InfoCommand.LineCommand
+short_description	lib/byebug/commands/info/program.rb	/^      def self.short_description$/;"	F	class:Byebug.InfoCommand.ProgramCommand
+short_description	lib/byebug/commands/interrupt.rb	/^    def self.short_description$/;"	F	class:Byebug.InterruptCommand
+short_description	lib/byebug/commands/irb.rb	/^    def self.short_description$/;"	F	class:Byebug.IrbCommand
+short_description	lib/byebug/commands/kill.rb	/^    def self.short_description$/;"	F	class:Byebug.KillCommand
+short_description	lib/byebug/commands/list.rb	/^    def self.short_description$/;"	F	class:Byebug.ListCommand
+short_description	lib/byebug/commands/method.rb	/^    def self.short_description$/;"	F	class:Byebug.MethodCommand.description
+short_description	lib/byebug/commands/next.rb	/^    def self.short_description$/;"	F	class:Byebug.NextCommand
+short_description	lib/byebug/commands/pry.rb	/^    def self.short_description$/;"	F	class:Byebug.PryCommand
+short_description	lib/byebug/commands/quit.rb	/^    def self.short_description$/;"	F	class:Byebug.QuitCommand
+short_description	lib/byebug/commands/restart.rb	/^    def self.short_description$/;"	F	class:Byebug.RestartCommand
+short_description	lib/byebug/commands/save.rb	/^    def self.short_description$/;"	F	class:Byebug.SaveCommand
+short_description	lib/byebug/commands/set.rb	/^    def self.short_description$/;"	F	class:Byebug.SetCommand
+short_description	lib/byebug/commands/show.rb	/^    def self.short_description$/;"	F	class:Byebug.ShowCommand
+short_description	lib/byebug/commands/skip.rb	/^    def self.short_description$/;"	F	class:Byebug
+short_description	lib/byebug/commands/source.rb	/^    def self.short_description$/;"	F	class:Byebug.SourceCommand
+short_description	lib/byebug/commands/step.rb	/^    def self.short_description$/;"	F	class:Byebug.StepCommand
+short_description	lib/byebug/commands/thread.rb	/^    def self.short_description$/;"	F	class:Byebug.ThreadCommand
+short_description	lib/byebug/commands/thread/current.rb	/^      def self.short_description$/;"	F	class:Byebug.ThreadCommand.CurrentCommand
+short_description	lib/byebug/commands/thread/list.rb	/^      def self.short_description$/;"	F	class:Byebug.ThreadCommand.ListCommand
+short_description	lib/byebug/commands/thread/resume.rb	/^      def self.short_description$/;"	F	class:Byebug.ThreadCommand.ResumeCommand
+short_description	lib/byebug/commands/thread/stop.rb	/^      def self.short_description$/;"	F	class:Byebug.ThreadCommand.StopCommand
+short_description	lib/byebug/commands/thread/switch.rb	/^      def self.short_description$/;"	F	class:Byebug.ThreadCommand.SwitchCommand
+short_description	lib/byebug/commands/tracevar.rb	/^    def self.short_description$/;"	F	class:Byebug.TracevarCommand
+short_description	lib/byebug/commands/undisplay.rb	/^    def self.short_description$/;"	F	class:Byebug.UndisplayCommand
+short_description	lib/byebug/commands/untracevar.rb	/^    def self.short_description$/;"	F	class:Byebug.UntracevarCommand
+short_description	lib/byebug/commands/up.rb	/^    def self.short_description$/;"	F	class:Byebug.UpCommand
+short_description	lib/byebug/commands/var.rb	/^    def self.short_description$/;"	F	class:Byebug.VarCommand
+short_description	lib/byebug/commands/var/all.rb	/^      def self.short_description$/;"	F	class:Byebug.VarCommand.AllCommand
+short_description	lib/byebug/commands/var/args.rb	/^      def self.short_description$/;"	F	class:Byebug.VarCommand.ArgsCommand
+short_description	lib/byebug/commands/var/const.rb	/^      def self.short_description$/;"	F	class:Byebug.VarCommand.ConstCommand
+short_description	lib/byebug/commands/var/global.rb	/^      def self.short_description$/;"	F	class:Byebug.VarCommand.GlobalCommand
+short_description	lib/byebug/commands/var/instance.rb	/^      def self.short_description$/;"	F	class:Byebug.VarCommand.InstanceCommand
+short_description	lib/byebug/commands/var/local.rb	/^      def self.short_description$/;"	F	class:Byebug.VarCommand.LocalCommand
+short_description	lib/byebug/commands/where.rb	/^    def self.short_description$/;"	F	class:Byebug.WhereCommand
+shortpath	lib/byebug/helpers/file.rb	/^      def shortpath(fullpath)$/;"	f	class:Byebug.Helpers.FileHelper
+show.rb	lib/byebug/commands/show.rb	1;"	F
+show_test.rb	test/commands/show_test.rb	1;"	F
+signature	test/support/assertions.rb	/^    def signature(method, *args)$/;"	f	class:Minitest.Assertions
+silent_eval	lib/byebug/helpers/eval.rb	/^      def silent_eval(str, binding = frame._binding)$/;"	f	class:Byebug.Helpers.EvalHelper
+simplecov.rb	test/support/simplecov.rb	1;"	F
+size	lib/byebug/source_file_formatter.rb	/^    def size$/;"	f	class:Byebug.SourceFileFormatter
+skip.rb	lib/byebug/commands/skip.rb	1;"	F
+skip_test.rb	test/commands/skip_test.rb	1;"	F
+source	ext/byebug/byebug.h	/^  VALUE source;$/;"	m	struct:__anon5	access:public
+source.rb	lib/byebug/commands/source.rb	1;"	F
+source_file_formatter	lib/byebug/commands/list.rb	/^    def source_file_formatter$/;"	f	class:Byebug.ListCommand
+source_file_formatter.rb	lib/byebug/source_file_formatter.rb	1;"	F
+source_test.rb	test/commands/source_test.rb	1;"	F
+spawn	lib/byebug/attacher.rb	/^  def self.spawn(host = "localhost", port = nil)$/;"	F	class:Byebug
+specific_max_size	lib/byebug/history.rb	/^    def specific_max_size(number)$/;"	f	class:Byebug.to_s
+split_commands	lib/byebug/interface.rb	/^    def split_commands(cmd_line)$/;"	f	class:Byebug.Interface
+split_lines	test/support/utils.rb	/^    def split_lines(output_str)$/;"	f	class:Byebug.TestUtils
+split_range	lib/byebug/commands/list.rb	/^    def split_range(str)$/;"	f	class:Byebug.ListCommand
+squares	test/processors/command_processor_test.rb	/^            def squares$/;"	f	class:ProcessorEvaluationAndThreadsTest.program.Byebug
+squish	docker/manager.rb	/^    def squish(command)$/;"	f	class:Docker
+stack_on_error.rb	lib/byebug/settings/stack_on_error.rb	1;"	F
+stack_size	lib/byebug/context.rb	/^    def stack_size$/;"	f	class:Byebug
+start	lib/byebug/remote/client.rb	/^      def start(host = "localhost", port = PORT)$/;"	f	class:Byebug.Remote.Client
+start	lib/byebug/remote/server.rb	/^      def start(host, port)$/;"	f	class:Byebug.Remote.Server
+start_client	lib/byebug/remote.rb	/^    def start_client(host = "localhost", port = PORT)$/;"	f	class:Byebug
+start_control	lib/byebug/remote.rb	/^    def start_control(host = nil, port = PORT + 1)$/;"	f	class:Byebug
+start_server	lib/byebug/remote.rb	/^    def start_server(host = nil, port = PORT)$/;"	f	class:Byebug
+started?	lib/byebug/remote/client.rb	/^      def started?$/;"	f	class:Byebug.Remote.Client
+status_flag	lib/byebug/helpers/thread.rb	/^      def status_flag(ctx)$/;"	f	class:Byebug.Helpers
+step.rb	lib/byebug/commands/step.rb	1;"	F
+step_steps_into_blocks	test/commands/step_test.rb	/^    def step_steps_into_blocks$/;"	f
+step_steps_out_of_blocks_when_done	test/commands/step_test.rb	/^    def step_steps_out_of_blocks_when_done$/;"	f
+step_test.rb	test/commands/step_test.rb	1;"	F
+steps	ext/byebug/byebug.h	/^  int steps;      \/* # of steps before stopping               *\/$/;"	m	struct:__anon2	access:public
+steps_out	ext/byebug/byebug.h	/^  int steps_out;  \/* # of returns before stopping             *\/$/;"	m	struct:__anon2	access:public
+stop	lib/byebug/option_setter.rb	/^    def stop$/;"	f
+stop.rb	lib/byebug/commands/thread/stop.rb	1;"	F
+stop_reason	ext/byebug/byebug.h	/^  ctx_stop_reason stop_reason;$/;"	m	struct:__anon2	access:public
+str_obj	lib/byebug/commands/var/const.rb	/^      def str_obj$/;"	f	class:Byebug.VarCommand.ConstCommand
+string.rb	lib/byebug/helpers/string.rb	1;"	F
+strip_line_numbers	test/support/utils.rb	/^    def strip_line_numbers(str_with_ruby_code)$/;"	f	class:Byebug.TestUtils
+subcommand	lib/byebug/commands/help.rb	/^    def subcommand$/;"	f	class:Byebug.HelpCommand
+subcommand_list	lib/byebug/subcommands.rb	/^      def subcommand_list$/;"	f	class:Byebug.Subcommands.ClassMethods
+subcommands.rb	lib/byebug/subcommands.rb	1;"	F
+switch.rb	lib/byebug/commands/thread/switch.rb	1;"	F
+switch_to_frame	lib/byebug/helpers/frame.rb	/^      def switch_to_frame(frame)$/;"	f	class:Byebug.Helpers.FrameHelper
+syntax_valid?	lib/byebug/helpers/parse.rb	/^      def syntax_valid?(code)$/;"	f	class:Byebug.Helpers.ParseHelper
+t1_context	test/commands/thread_test.rb	/^    def t1_context$/;"	f
+t1_thnum	test/commands/thread_test.rb	/^    def t1_thnum$/;"	f
+t2_context	test/commands/thread_test.rb	/^    def t2_context$/;"	f
+t2_thnum	test/commands/thread_test.rb	/^    def t2_thnum$/;"	f
+t_tbl_free	ext/byebug/threads.c	/^t_tbl_free(void *data)$/;"	f	file:	signature:(void *data)
+t_tbl_mark	ext/byebug/threads.c	/^t_tbl_mark(void *data)$/;"	f	file:	signature:(void *data)
+t_tbl_mark_keyvalue	ext/byebug/threads.c	/^t_tbl_mark_keyvalue(st_data_t key, st_data_t value, st_data_t tbl)$/;"	f	file:	signature:(st_data_t key, st_data_t value, st_data_t tbl)
+tag	docker/manager.rb	/^    def tag$/;"	f	class:Docker
+target_object	lib/byebug/commands/break.rb	/^    def target_object(str)$/;"	f	class:Byebug.BreakCommand
+tbl	ext/byebug/byebug.h	/^  st_table *tbl;$/;"	m	struct:__anon4	access:public
+teardown	test/commands/finish_test.rb	/^    def teardown$/;"	f
+teardown	test/commands/source_test.rb	/^    def teardown$/;"	f
+teardown	test/commands/where_test.rb	/^    def teardown$/;"	f	class:WhereWithDeeplyNestedPathsTest
+teardown	test/interface_test.rb	/^    def teardown$/;"	f	class:Byebug.InterfaceTest
+teardown	test/support/test_case.rb	/^    def teardown$/;"	f	class:Byebug.TestCase
+temporary.rb	test/support/temporary.rb	1;"	F
+test	docker/manager.rb	/^    def test$/;"	f	class:Docker.Manager
+test_add_yn_to_the_confirmation_strings	test/printers/plain_test.rb	/^    def test_add_yn_to_the_confirmation_strings$/;"	f	class:Byebug.PrintersPlainTest
+test_aliases_debugger_to_byebug	test/debugger_alias_test.rb	/^    def test_aliases_debugger_to_byebug$/;"	f	class:Byebug.DebuggerAliasTest
+test_all	docker/manager.rb	/^      def test_all$/;"	f	class:Docker.Manager
+test_arithmetic_expressions_are_evaluated_on_unknown_input	test/processors/command_processor_test.rb	/^    def test_arithmetic_expressions_are_evaluated_on_unknown_input$/;"	f
+test_arrays_are_properly_printed_after_evaluation_of_unknown_input	test/processors/command_processor_test.rb	/^    def test_arrays_are_properly_printed_after_evaluation_of_unknown_input$/;"	f
+test_asks_for_confirmation	test/commands/undisplay_test.rb	/^    def test_asks_for_confirmation$/;"	f	class:Byebug
+test_autoirb_calls_irb_automatically_after_every_stop	test/commands/irb_test.rb	/^    def test_autoirb_calls_irb_automatically_after_every_stop$/;"	f	class:Byebug
+test_autolists_lists_source_before_stopping	test/processors/command_processor_test.rb	/^    def test_autolists_lists_source_before_stopping$/;"	f
+test_autopry_calls_pry_automatically_after_every_stop	test/commands/pry_test.rb	/^    def test_autopry_calls_pry_automatically_after_every_stop$/;"	f	class:Byebug
+test_basename_setting_affects_tracing_output	test/commands/set_test.rb	/^    def test_basename_setting_affects_tracing_output$/;"	f
+test_break_with_a_method_does_not_stop_at_blocks_in_the_method	test/commands/break_test.rb	/^    def test_break_with_a_method_does_not_stop_at_blocks_in_the_method$/;"	f
+test_break_with_class_method_stops_at_correct_place	test/commands/break_test.rb	/^    def test_break_with_class_method_stops_at_correct_place$/;"	f
+test_break_with_instance_method_stops_at_correct_place	test/commands/break_test.rb	/^    def test_break_with_instance_method_stops_at_correct_place$/;"	f
+test_break_with_module_method_stops_at_correct_place	test/commands/break_test.rb	/^    def test_break_with_module_method_stops_at_correct_place$/;"	f
+test_break_with_namespaced_class_method_stops_at_correct_place	test/commands/break_test.rb	/^    def test_break_with_namespaced_class_method_stops_at_correct_place$/;"	f
+test_break_with_namespaced_instance_method_stops_at_correct_place	test/commands/break_test.rb	/^    def test_break_with_namespaced_instance_method_stops_at_correct_place$/;"	f
+test_break_with_namespaced_module_method_stops_at_correct_place	test/commands/break_test.rb	/^    def test_break_with_namespaced_module_method_stops_at_correct_place$/;"	f
+test_break_with_oneline_instance_method_stops_at_correct_place	test/commands/break_test.rb	/^    def test_break_with_oneline_instance_method_stops_at_correct_place$/;"	f
+test_breaking_w_byebug_keyword_stops_at_the_next_line	test/commands/break_test.rb	/^    def test_breaking_w_byebug_keyword_stops_at_the_next_line$/;"	f
+test_case.rb	test/support/test_case.rb	1;"	F
+test_catch_adds_catchpoints	test/commands/catch_test.rb	/^    def test_catch_adds_catchpoints$/;"	f	class:Byebug.CatchTest
+test_catch_off_removes_all_catchpoints_after_confirmation	test/commands/catch_test.rb	/^    def test_catch_off_removes_all_catchpoints_after_confirmation$/;"	f	class:Byebug.CatchTest
+test_catch_removes_specific_catchpoint	test/commands/catch_test.rb	/^    def test_catch_removes_specific_catchpoint$/;"	f	class:Byebug.CatchTest
+test_cmds_from_previous_repls_are_not_remembered_if_autosave_disabled	test/commands/history_test.rb	/^      def test_cmds_from_previous_repls_are_not_remembered_if_autosave_disabled$/;"	f	class:Byebug
+test_cmds_from_previous_repls_are_remembered_if_autosave_enabled	test/commands/history_test.rb	/^      def test_cmds_from_previous_repls_are_remembered_if_autosave_enabled$/;"	f	class:Byebug
+test_combinations	test/minitest_runner_test.rb	/^    def test_combinations$/;"	f	class:Byebug.MinitestRunnerTest
+test_command_forbidden_in_post_mortem_mode	test/post_mortem_test.rb	/^    def test_command_forbidden_in_post_mortem_mode$/;"	f
+test_command_permitted_in_post_mortem_mode	test/post_mortem_test.rb	/^    def test_command_permitted_in_post_mortem_mode$/;"	f
+test_conditional_breakpoint_is_ignored_if_condition_is_false	test/commands/break_test.rb	/^    def test_conditional_breakpoint_is_ignored_if_condition_is_false$/;"	f
+test_conditional_breakpoint_stops_if_condition_is_true	test/commands/break_test.rb	/^    def test_conditional_breakpoint_stops_if_condition_is_true$/;"	f
+test_conditions_with_wrong_syntax_are_ignored	test/commands/condition_test.rb	/^    def test_conditions_with_wrong_syntax_are_ignored$/;"	f	class:Byebug
+test_connecting_to_remote_debugger	test/support/remote_debugging_tests.rb	/^    def test_connecting_to_remote_debugger$/;"	f	class:Byebug.RemoteDebuggingTests
+test_continues_by_control_d	test/interfaces/local_interface_test.rb	/^    def test_continues_by_control_d$/;"	f	class:Byebug.LocalInterfaceTest
+test_continues_until_the_end_if_no_line_specified_and_no_breakpoints	test/commands/continue_test.rb	/^    def test_continues_until_the_end_if_no_line_specified_and_no_breakpoints$/;"	f
+test_continues_until_the_end_if_no_line_specified_and_no_breakpoints	test/commands/skip_test.rb	/^    def test_continues_until_the_end_if_no_line_specified_and_no_breakpoints$/;"	f
+test_continues_until_the_end_if_used_with_bang	test/commands/continue_test.rb	/^    def test_continues_until_the_end_if_used_with_bang$/;"	f
+test_continues_until_the_end_if_used_with_unconditionally	test/commands/continue_test.rb	/^    def test_continues_until_the_end_if_used_with_unconditionally$/;"	f
+test_continues_until_the_end_ignoring_byebug_calls_if_used_with_bang	test/commands/continue_test.rb	/^    def test_continues_until_the_end_ignoring_byebug_calls_if_used_with_bang$/;"	f
+test_continues_until_the_end_ignoring_byebug_calls_if_used_with_unconditionally	test/commands/continue_test.rb	/^    def test_continues_until_the_end_ignoring_byebug_calls_if_used_with_unconditionally$/;"	f
+test_continues_up_to_breakpoint_if_no_line_specified	test/commands/continue_test.rb	/^    def test_continues_up_to_breakpoint_if_no_line_specified$/;"	f
+test_continues_up_to_the_specified_line	test/commands/continue_test.rb	/^    def test_continues_up_to_the_specified_line$/;"	f
+test_correctly_print_lines_containing_the_percentage_symbol	test/commands/list_test.rb	/^    def test_correctly_print_lines_containing_the_percentage_symbol$/;"	f
+test_default	docker/manager.rb	/^      def test_default$/;"	f	class:Docker.Manager
+test_delete_by_itself_deletes_all_breakpoints_if_confirmed	test/commands/delete_test.rb	/^    def test_delete_by_itself_deletes_all_breakpoints_if_confirmed$/;"	f
+test_delete_by_itself_keeps_current_breakpoints_if_not_confirmed	test/commands/delete_test.rb	/^    def test_delete_by_itself_keeps_current_breakpoints_if_not_confirmed$/;"	f
+test_delete_with_an_invalid_breakpoint_id_shows_error	test/commands/delete_test.rb	/^    def test_delete_with_an_invalid_breakpoint_id_shows_error$/;"	f
+test_deleting_a_breakpoint_removes_it_from_breakpoints_list	test/commands/delete_test.rb	/^    def test_deleting_a_breakpoint_removes_it_from_breakpoints_list$/;"	f
+test_deleting_a_breakpoint_shows_a_success_message	test/commands/delete_test.rb	/^    def test_deleting_a_breakpoint_shows_a_success_message$/;"	f
+test_disable_all_breakpoints_ignores_all_breakpoints	test/commands/disable_test.rb	/^    def test_disable_all_breakpoints_ignores_all_breakpoints$/;"	f
+test_disable_all_breakpoints_sets_all_enabled_flags_to_false	test/commands/disable_test.rb	/^    def test_disable_all_breakpoints_sets_all_enabled_flags_to_false$/;"	f
+test_disable_all_breakpoints_shows_success_messages_for_all_breakpoints	test/commands/disable_test.rb	/^    def test_disable_all_breakpoints_shows_success_messages_for_all_breakpoints$/;"	f
+test_disable_display_removes_the_expression_from_display_list	test/commands/undisplay_test.rb	/^    def test_disable_display_removes_the_expression_from_display_list$/;"	f	class:Byebug
+test_disable_display_shows_an_error_if_no_displays_are_set	test/commands/undisplay_test.rb	/^    def test_disable_display_shows_an_error_if_no_displays_are_set$/;"	f	class:Byebug
+test_disable_display_shows_an_error_if_theres_no_such_display_position	test/commands/undisplay_test.rb	/^    def test_disable_display_shows_an_error_if_theres_no_such_display_position$/;"	f	class:Byebug
+test_disable_specific_breakpoints_properly_ignores_them	test/commands/disable_test.rb	/^    def test_disable_specific_breakpoints_properly_ignores_them$/;"	f
+test_disable_specific_breakpoints_sets_enabled_to_false	test/commands/disable_test.rb	/^    def test_disable_specific_breakpoints_sets_enabled_to_false$/;"	f
+test_disable_specific_breakpoints_shows_success_message	test/commands/disable_test.rb	/^    def test_disable_specific_breakpoints_shows_success_message$/;"	f
+test_disable_with_an_incorrect_breakpoint_number_shows_error	test/commands/disable_test.rb	/^    def test_disable_with_an_incorrect_breakpoint_number_shows_error$/;"	f
+test_disable_without_an_argument_shows_help	test/commands/disable_test.rb	/^    def test_disable_without_an_argument_shows_help$/;"	f
+test_displays_all_expressions_available	test/commands/display_test.rb	/^    def test_displays_all_expressions_available$/;"	f	class:Byebug
+test_displays_only_the_active_position	test/commands/undisplay_test.rb	/^    def test_displays_only_the_active_position$/;"	f	class:Byebug
+test_does_not_hang_when_evaluating_expressions_using_new_threads	test/processors/command_processor_test.rb	/^    def test_does_not_hang_when_evaluating_expressions_using_new_threads$/;"	f
+test_does_not_hang_when_evaluating_expressions_using_old_threads	test/processors/command_processor_test.rb	/^    def test_does_not_hang_when_evaluating_expressions_using_old_threads$/;"	f
+test_does_not_list_after_the_end_of_file	test/commands/list_test.rb	/^    def test_does_not_list_after_the_end_of_file$/;"	f
+test_does_not_list_before_the_beginning_of_file	test/commands/list_test.rb	/^    def test_does_not_list_before_the_beginning_of_file$/;"	f
+test_does_not_list_code_for_intermediate_breakpoints	test/commands/skip_test.rb	/^    def test_does_not_list_code_for_intermediate_breakpoints$/;"	f
+test_does_not_quit_if_user_did_not_confirm	test/commands/quit_test.rb	/^    def test_does_not_quit_if_user_did_not_confirm$/;"	f	class:Byebug.QuitTest
+test_does_not_remove_all_expressions_from_list_unless_confirmed	test/commands/undisplay_test.rb	/^    def test_does_not_remove_all_expressions_from_list_unless_confirmed$/;"	f	class:Byebug
+test_does_not_show_incorrect_info_about_having_stopped_at_breakpoint	test/processors/command_processor_test.rb	/^    def test_does_not_show_incorrect_info_about_having_stopped_at_breakpoint$/;"	f
+test_does_not_show_return_value_information	test/commands/break_test.rb	/^    def test_does_not_show_return_value_information$/;"	f
+test_does_not_stop_at_the_deleted_breakpoint	test/commands/delete_test.rb	/^    def test_does_not_stop_at_the_deleted_breakpoint$/;"	f
+test_down_autolists_new_source_location_when_autolist_enabled	test/commands/down_test.rb	/^    def test_down_autolists_new_source_location_when_autolist_enabled$/;"	f
+test_down_does_not_autolist_new_source_location_when_autolist_disabled	test/commands/down_test.rb	/^    def test_down_does_not_autolist_new_source_location_when_autolist_disabled$/;"	f
+test_down_does_not_move_if_frame_number_to_too_low	test/commands/down_test.rb	/^    def test_down_does_not_move_if_frame_number_to_too_low$/;"	f
+test_down_moves_down_in_the_callstack	test/commands/down_test.rb	/^    def test_down_moves_down_in_the_callstack$/;"	f
+test_down_moves_down_in_the_callstack_a_specific_number_of_frames	test/commands/down_test.rb	/^    def test_down_moves_down_in_the_callstack_a_specific_number_of_frames$/;"	f
+test_down_skips_c_frames	test/commands/down_test.rb	/^    def test_down_skips_c_frames$/;"	f
+test_edit_accepts_no_line_specification	test/commands/edit_test.rb	/^    def test_edit_accepts_no_line_specification$/;"	f
+test_edit_calls_vim_if_no_editor_environment_variable_is_set	test/commands/edit_test.rb	/^    def test_edit_calls_vim_if_no_editor_environment_variable_is_set$/;"	f
+test_edit_opens_configured_editor_at_specific_line_and_file	test/commands/edit_test.rb	/^    def test_edit_opens_configured_editor_at_specific_line_and_file$/;"	f
+test_edit_opens_current_file_in_current_line_in_configured_editor	test/commands/edit_test.rb	/^    def test_edit_opens_current_file_in_current_line_in_configured_editor$/;"	f	class:Byebug.EditTest
+test_edit_shows_an_error_if_specified_file_does_not_exist	test/commands/edit_test.rb	/^    def test_edit_shows_an_error_if_specified_file_does_not_exist$/;"	f
+test_edit_shows_an_error_if_the_specified_file_is_not_readable	test/commands/edit_test.rb	/^    def test_edit_shows_an_error_if_the_specified_file_is_not_readable$/;"	f
+test_empty_command_repeats_last_command	test/processors/command_processor_test.rb	/^    def test_empty_command_repeats_last_command$/;"	f	class:Byebug
+test_empty_condition_means_removing_any_conditions	test/commands/condition_test.rb	/^    def test_empty_condition_means_removing_any_conditions$/;"	f	class:Byebug
+test_enable_all_breakpoints_sets_all_enabled_flags_to_true	test/commands/enable_test.rb	/^    def test_enable_all_breakpoints_sets_all_enabled_flags_to_true$/;"	f
+test_enable_all_breakpoints_shows_success_messages_for_all_breakpoints	test/commands/enable_test.rb	/^    def test_enable_all_breakpoints_shows_success_messages_for_all_breakpoints$/;"	f
+test_enable_all_breakpoints_stops_at_first_breakpoint	test/commands/enable_test.rb	/^    def test_enable_all_breakpoints_stops_at_first_breakpoint$/;"	f
+test_enable_all_breakpoints_stops_at_last_breakpoint	test/commands/enable_test.rb	/^    def test_enable_all_breakpoints_stops_at_last_breakpoint$/;"	f
+test_enable_by_itself_shows_help	test/commands/enable_test.rb	/^    def test_enable_by_itself_shows_help$/;"	f
+test_enable_display_set_display_flag_to_true_in_display_list	test/commands/undisplay_test.rb	/^    def test_enable_display_set_display_flag_to_true_in_display_list$/;"	f	class:Byebug
+test_enable_specific_breakpoints_sets_enabled_to_true	test/commands/enable_test.rb	/^    def test_enable_specific_breakpoints_sets_enabled_to_true$/;"	f
+test_enable_specific_breakpoints_shows_success_message	test/commands/enable_test.rb	/^    def test_enable_specific_breakpoints_shows_success_message$/;"	f
+test_enable_specific_breakpoints_stops_at_enabled_breakpoint	test/commands/enable_test.rb	/^    def test_enable_specific_breakpoints_stops_at_enabled_breakpoint$/;"	f
+test_enable_with_an_incorrect_breakpoint_number_shows_error	test/commands/enable_test.rb	/^    def test_enable_with_an_incorrect_breakpoint_number_shows_error$/;"	f
+test_error_if_there_is_no_specified_argument	test/printers/plain_test.rb	/^    def test_error_if_there_is_no_specified_argument$/;"	f	class:Byebug.PrintersPlainTest
+test_error_if_there_is_no_specified_path	test/printers/plain_test.rb	/^    def test_error_if_there_is_no_specified_path$/;"	f	class:Byebug.PrintersPlainTest
+test_eval_evaluates_just_like_without_it	test/processors/command_processor_test.rb	/^    def test_eval_evaluates_just_like_without_it$/;"	f
+test_evaluation_results_on_unknown_input_prefer_inspect_over_to_s	test/processors/command_processor_test.rb	/^    def test_evaluation_results_on_unknown_input_prefer_inspect_over_to_s$/;"	f
+test_execution_does_not_stop_when_condition_is_false	test/commands/condition_test.rb	/^    def test_execution_does_not_stop_when_condition_is_false$/;"	f	class:Byebug
+test_execution_is_stopped_at_the_correct_line_after_exception	test/post_mortem_test.rb	/^    def test_execution_is_stopped_at_the_correct_line_after_exception$/;"	f
+test_execution_stops_when_condition_is_true	test/commands/condition_test.rb	/^    def test_execution_stops_when_condition_is_true$/;"	f	class:Byebug
+test_files	lib/byebug/helpers/path.rb	/^      def test_files$/;"	f	class:Byebug.Helpers.PathHelper
+test_finish_0_shows_information_about_the_return_value	test/commands/finish_test.rb	/^    def test_finish_0_shows_information_about_the_return_value$/;"	f
+test_finish_0_stops_right_before_frame_returns__convoluted_case	test/commands/finish_test.rb	/^    def test_finish_0_stops_right_before_frame_returns__convoluted_case$/;"	f
+test_finish_0_stops_right_before_frame_returns__simple_case	test/commands/finish_test.rb	/^    def test_finish_0_stops_right_before_frame_returns__simple_case$/;"	f
+test_finish_1_stops_after_current_frame_is_finished	test/commands/finish_test.rb	/^    def test_finish_1_stops_after_current_frame_is_finished$/;"	f
+test_finish_behaves_consistenly_even_if_current_frame_has_been_changed	test/commands/finish_test.rb	/^    def test_finish_behaves_consistenly_even_if_current_frame_has_been_changed$/;"	f
+test_finish_does_not_stop_in_byebug_internal_frames	test/commands/finish_test.rb	/^    def test_finish_does_not_stop_in_byebug_internal_frames$/;"	f
+test_finish_inside_autoloaded_files	test/commands/finish_test.rb	/^    def test_finish_inside_autoloaded_files$/;"	f
+test_finish_shows_an_error_if_incorrect_frame_number_specified	test/commands/finish_test.rb	/^    def test_finish_shows_an_error_if_incorrect_frame_number_specified$/;"	f
+test_finish_stays_at_the_same_line_if_incorrect_frame_number_specified	test/commands/finish_test.rb	/^    def test_finish_stays_at_the_same_line_if_incorrect_frame_number_specified$/;"	f
+test_finish_stops_after_current_multiline_frame_is_finished	test/commands/finish_test.rb	/^    def test_finish_stops_after_current_multiline_frame_is_finished$/;"	f
+test_finish_stops_after_current_single_line_frame_is_finished	test/commands/finish_test.rb	/^    def test_finish_stops_after_current_single_line_frame_is_finished$/;"	f
+test_finish_works_for_frame_numbers_higher_than_one	test/commands/finish_test.rb	/^    def test_finish_works_for_frame_numbers_higher_than_one$/;"	f
+test_frame_0_sets_frame_to_the_first_one	test/commands/frame_test.rb	/^    def test_frame_0_sets_frame_to_the_first_one$/;"	f
+test_frame_autolists_new_source_location_when_autolist_enabled	test/commands/frame_test.rb	/^    def test_frame_autolists_new_source_location_when_autolist_enabled$/;"	f
+test_frame_cannot_navigate_to_c_frames	test/commands/frame_test.rb	/^    def test_frame_cannot_navigate_to_c_frames$/;"	f
+test_frame_does_not_autolist_new_source_location_when_autolist_disabled	test/commands/frame_test.rb	/^    def test_frame_does_not_autolist_new_source_location_when_autolist_disabled$/;"	f
+test_frame_minus_one_sets_frame_to_the_last_one	test/commands/frame_test.rb	/^    def test_frame_minus_one_sets_frame_to_the_last_one$/;"	f
+test_frame_moves_to_a_specific_frame	test/commands/frame_test.rb	/^    def test_frame_moves_to_a_specific_frame$/;"	f
+test_frame_prints_the_callstack_when_called_without_arguments	test/commands/frame_test.rb	/^    def test_frame_prints_the_callstack_when_called_without_arguments$/;"	f
+test_gives_back_a_prompt_when_invoked_with_invalid_syntax	test/commands/list_test.rb	/^    def test_gives_back_a_prompt_when_invoked_with_invalid_syntax$/;"	f
+test_has_definitions_for_all_releases	test/changelog_test.rb	/^    def test_has_definitions_for_all_releases$/;"	f	class:Byebug.ChangelogTest
+test_help_help_shows_help_for_help_command_itself	test/commands/help_test.rb	/^    def test_help_help_shows_help_for_help_command_itself$/;"	f	class:HelpWithArgsTest
+test_help_set_shows_help_for_set_command_and_includes_settings	test/commands/help_test.rb	/^    def test_help_set_shows_help_for_set_command_and_includes_settings$/;"	f	class:HelpWithArgsTest
+test_help_show_shows_help_for_show_command_and_includes_settings	test/commands/help_test.rb	/^    def test_help_show_shows_help_for_show_command_and_includes_settings$/;"	f	class:HelpWithArgsTest
+test_help_with_command_and_subcommand_shows_subcommands_help	test/commands/help_test.rb	/^    def test_help_with_command_and_subcommand_shows_subcommands_help$/;"	f	class:HelpWithArgsTest
+test_help_with_specific_command_shows_help_for_it	test/commands/help_test.rb	/^    def test_help_with_specific_command_shows_help_for_it$/;"	f	class:HelpWithArgsTest
+test_help_with_undefined_command_shows_an_error	test/commands/help_test.rb	/^    def test_help_with_undefined_command_shows_an_error$/;"	f	class:HelpWithArgsTest
+test_help_with_undefined_subcommand_shows_an_error	test/commands/help_test.rb	/^    def test_help_with_undefined_subcommand_shows_an_error$/;"	f	class:HelpWithArgsTest
+test_helper.rb	test/test_helper.rb	1;"	F
+test_history_displays_latest_records_from_readline_history	test/commands/history_test.rb	/^      def test_history_displays_latest_records_from_readline_history$/;"	f	class:Byebug
+test_history_does_not_save_duplicated_consecutive_commands	test/commands/history_test.rb	/^      def test_history_does_not_save_duplicated_consecutive_commands$/;"	f	class:Byebug
+test_history_does_not_save_empty_commands	test/commands/history_test.rb	/^      def test_history_does_not_save_empty_commands$/;"	f	class:Byebug
+test_history_n_displays_lastest_n_records_from_readline_history	test/commands/history_test.rb	/^      def test_history_n_displays_lastest_n_records_from_readline_history$/;"	f	class:Byebug
+test_history_n_displays_whole_history_if_n_is_bigger_than_history_size	test/commands/history_test.rb	/^      def test_history_n_displays_whole_history_if_n_is_bigger_than_history_size$/;"	f	class:Byebug
+test_ignores_the_command_if_specified_line_is_not_valid	test/commands/continue_test.rb	/^    def test_ignores_the_command_if_specified_line_is_not_valid$/;"	f
+test_ignoring_main_server_and_control_threads	test/support/remote_debugging_tests.rb	/^    def test_ignoring_main_server_and_control_threads$/;"	f	class:Byebug.RemoteDebuggingTests
+test_info_alone_shows_help	test/commands/info_test.rb	/^    def test_info_alone_shows_help$/;"	f
+test_info_breakpoints_shows_a_message_when_no_breakpoints_found	test/commands/info_test.rb	/^    def test_info_breakpoints_shows_a_message_when_no_breakpoints_found$/;"	f
+test_info_breakpoints_shows_error_if_specific_breakpoint_do_not_exist	test/commands/info_test.rb	/^    def test_info_breakpoints_shows_error_if_specific_breakpoint_do_not_exist$/;"	f
+test_info_breakpoints_shows_hit_counts	test/commands/info_test.rb	/^    def test_info_breakpoints_shows_hit_counts$/;"	f
+test_info_breakpoints_shows_information_about_all_breakpoints	test/commands/info_test.rb	/^    def test_info_breakpoints_shows_information_about_all_breakpoints$/;"	f
+test_info_breakpoints_with_ids_shows_information_on_specific_breakpoints	test/commands/info_test.rb	/^    def test_info_breakpoints_with_ids_shows_information_on_specific_breakpoints$/;"	f
+test_info_display_shows_a_message_when_no_display_expressions_found	test/commands/info_test.rb	/^    def test_info_display_shows_a_message_when_no_display_expressions_found$/;"	f
+test_info_display_shows_all_display_expressions	test/commands/info_test.rb	/^    def test_info_display_shows_all_display_expressions$/;"	f
+test_info_file_does_not_show_any_info_if_filename_is_invalid	test/commands/info_test.rb	/^    def test_info_file_does_not_show_any_info_if_filename_is_invalid$/;"	f
+test_info_file_shows_basic_info_about_current_file	test/commands/info_test.rb	/^    def test_info_file_shows_basic_info_about_current_file$/;"	f
+test_info_file_shows_mtime_of_current_file	test/commands/info_test.rb	/^    def test_info_file_shows_mtime_of_current_file$/;"	f
+test_info_file_shows_potential_breakpoint_lines_in_current_file	test/commands/info_test.rb	/^    def test_info_file_shows_potential_breakpoint_lines_in_current_file$/;"	f
+test_info_file_shows_sha1_signature_of_current_file	test/commands/info_test.rb	/^    def test_info_file_shows_sha1_signature_of_current_file$/;"	f
+test_info_file_w_filename_shows_mtime_of_filename	test/commands/info_test.rb	/^    def test_info_file_w_filename_shows_mtime_of_filename$/;"	f
+test_info_file_w_filename_shows_potential_breakpoint_lines_in_filename	test/commands/info_test.rb	/^    def test_info_file_w_filename_shows_potential_breakpoint_lines_in_filename$/;"	f
+test_info_file_w_filename_shows_sha1_signature_of_filename	test/commands/info_test.rb	/^    def test_info_file_w_filename_shows_sha1_signature_of_filename$/;"	f
+test_info_file_with_a_file_name_shows_basic_info_about_a_specific_file	test/commands/info_test.rb	/^    def test_info_file_with_a_file_name_shows_basic_info_about_a_specific_file$/;"	f
+test_info_file_with_a_file_name_with_space_doesnt_fail	test/commands/info_test.rb	/^    def test_info_file_with_a_file_name_with_space_doesnt_fail$/;"	f
+test_info_line_shows_info_about_the_current_line	test/commands/info_test.rb	/^    def test_info_line_shows_info_about_the_current_line$/;"	f
+test_info_program_shows_the_breakpoint_stop_reason	test/commands/info_test.rb	/^    def test_info_program_shows_the_breakpoint_stop_reason$/;"	f
+test_info_program_shows_the_catchpoint_stop_reason_for_crashed_programs	test/commands/info_test.rb	/^    def test_info_program_shows_the_catchpoint_stop_reason_for_crashed_programs$/;"	f	class:InfoCrashedTest
+test_info_program_shows_the_initial_stop_reason	test/commands/info_test.rb	/^    def test_info_program_shows_the_initial_stop_reason$/;"	f
+test_info_program_shows_the_step_stop_reason	test/commands/info_test.rb	/^    def test_info_program_shows_the_step_stop_reason$/;"	f
+test_initialize_verbose_writes_to_stdout_and_stderr	test/interfaces/script_interface_test.rb	/^    def test_initialize_verbose_writes_to_stdout_and_stderr$/;"	f	class:Byebug
+test_initialize_wires_up_dependencies	test/interfaces/script_interface_test.rb	/^    def test_initialize_wires_up_dependencies$/;"	f	class:Byebug.ScriptInterfaceTest
+test_interacting_with_remote_debugger	test/support/remote_debugging_tests.rb	/^    def test_interacting_with_remote_debugger$/;"	f	class:Byebug.RemoteDebuggingTests
+test_interface.rb	lib/byebug/interfaces/test_interface.rb	1;"	F
+test_interrupt_steps_into_blocks	test/commands/interrupt_test.rb	/^    def test_interrupt_steps_into_blocks$/;"	f	class:Byebug
+test_interrupt_stops_at_the_next_statement	test/commands/interrupt_test.rb	/^    def test_interrupt_stops_at_the_next_statement$/;"	f	class:Byebug
+test_interrupting_client_doesnt_abort_server	test/support/remote_debugging_tests.rb	/^    def test_interrupting_client_doesnt_abort_server$/;"	f	class:Byebug.RemoteDebuggingTests
+test_interrupting_client_doesnt_abort_server_after_a_second_breakpoint	test/remote_debugging_test.rb	/^    def test_interrupting_client_doesnt_abort_server_after_a_second_breakpoint$/;"	f
+test_irb_command_starts_an_irb_session	test/commands/irb_test.rb	/^    def test_irb_command_starts_an_irb_session$/;"	f	class:Byebug
+test_keeps_an_internal_command_buffer	test/interface_test.rb	/^    def test_keeps_an_internal_command_buffer$/;"	f	class:Byebug.InterfaceTest
+test_kill_asks_confirmation_when_sending_kill_implicitly	test/commands/kill_test.rb	/^    def test_kill_asks_confirmation_when_sending_kill_implicitly$/;"	f
+test_kill_closes_interface_when_sending_kill_signal_explicitly	test/commands/kill_test.rb	/^    def test_kill_closes_interface_when_sending_kill_signal_explicitly$/;"	f
+test_kill_does_not_send_an_unknown_signal	test/commands/kill_test.rb	/^    def test_kill_does_not_send_an_unknown_signal$/;"	f
+test_kill_sends_signal_to_some_pid	test/commands/kill_test.rb	/^    def test_kill_sends_signal_to_some_pid$/;"	f
+test_kill_shows_an_error_when_the_signal_is_unknown	test/commands/kill_test.rb	/^    def test_kill_shows_an_error_when_the_signal_is_unknown$/;"	f
+test_linetrace_does_not_show_a_line_in_eval_context	test/commands/continue_test.rb	/^    def test_linetrace_does_not_show_a_line_in_eval_context$/;"	f
+test_list_proper_lines_when_range_around_specific_line_with_comma	test/commands/list_test.rb	/^    def test_list_proper_lines_when_range_around_specific_line_with_comma$/;"	f
+test_list_proper_lines_when_range_around_specific_line_with_hyphen	test/commands/list_test.rb	/^    def test_list_proper_lines_when_range_around_specific_line_with_hyphen$/;"	f
+test_lists_backwards_after_the_second_call_to_list_minus	test/commands/list_test.rb	/^    def test_lists_backwards_after_the_second_call_to_list_minus$/;"	f
+test_lists_backwards_from_end_of_file	test/commands/list_test.rb	/^    def test_lists_backwards_from_end_of_file$/;"	f
+test_lists_file_changes	test/commands/list_test.rb	/^    def test_lists_file_changes$/;"	f
+test_lists_forwards_after_the_second_call_to_list	test/commands/list_test.rb	/^    def test_lists_forwards_after_the_second_call_to_list$/;"	f
+test_lists_nothing_if_invalid_range_is_specified	test/commands/list_test.rb	/^    def test_lists_nothing_if_invalid_range_is_specified$/;"	f
+test_lists_nothing_if_unexistent_range_is_specified	test/commands/list_test.rb	/^    def test_lists_nothing_if_unexistent_range_is_specified$/;"	f
+test_lists_source_code_lines	test/commands/list_test.rb	/^    def test_lists_source_code_lines$/;"	f
+test_lists_specific_range_when_requested_in_comma_format	test/commands/list_test.rb	/^    def test_lists_specific_range_when_requested_in_comma_format$/;"	f
+test_lists_specific_range_when_requested_in_hyphen_format	test/commands/list_test.rb	/^    def test_lists_specific_range_when_requested_in_hyphen_format$/;"	f
+test_lists_surrounding_lines_after_the_first_call_to_list_minus	test/commands/list_test.rb	/^    def test_lists_surrounding_lines_after_the_first_call_to_list_minus$/;"	f
+test_lists_surrounding_lines_when_list_equals_is_called	test/commands/list_test.rb	/^    def test_lists_surrounding_lines_when_list_equals_is_called$/;"	f
+test_lists_the_whole_file_if_number_of_lines_is_smaller_than_listsize	test/commands/list_test.rb	/^    def test_lists_the_whole_file_if_number_of_lines_is_smaller_than_listsize$/;"	f
+test_listsize_is_not_set_if_parameter_is_not_an_integer	test/commands/list_test.rb	/^    def test_listsize_is_not_set_if_parameter_is_not_an_integer$/;"	f
+test_m_shows_an_error_if_specified_object_is_not_a_class_or_module	test/commands/method_test.rb	/^    def test_m_shows_an_error_if_specified_object_is_not_a_class_or_module$/;"	f
+test_marks_specific_expression_from_list_as_inactive	test/commands/undisplay_test.rb	/^    def test_marks_specific_expression_from_list_as_inactive$/;"	f	class:Byebug
+test_method_instance_shows_methods_of_object	test/commands/method_test.rb	/^    def test_method_instance_shows_methods_of_object$/;"	f
+test_method_shows_instance_methods_of_a_class	test/commands/method_test.rb	/^    def test_method_shows_instance_methods_of_a_class$/;"	f
+test_methods	test/minitest_runner.rb	/^    def test_methods(str)$/;"	f	class:Byebug
+test_multiple_commands_are_executed_sequentially	test/processors/command_processor_test.rb	/^    def test_multiple_commands_are_executed_sequentially$/;"	f	class:Byebug
+test_n_goes_to_the_next_line	test/commands/next_test.rb	/^    def test_n_goes_to_the_next_line$/;"	f
+test_next_does_not_enter_other_frames_of_the_same_size	test/commands/next_test.rb	/^    def test_next_does_not_enter_other_frames_of_the_same_size$/;"	f
+test_next_does_not_stop_at_byebug_internal_frames	test/commands/next_test.rb	/^    def test_next_does_not_stop_at_byebug_internal_frames$/;"	f
+test_next_goes_to_the_next_line	test/commands/next_test.rb	/^    def test_next_goes_to_the_next_line$/;"	f
+test_next_goes_up_a_frame_if_current_frame_finishes	test/commands/next_test.rb	/^    def test_next_goes_up_a_frame_if_current_frame_finishes$/;"	f
+test_next_goes_up_a_frame_when_current_frame_finishes	test/commands/next_test.rb	/^    def test_next_goes_up_a_frame_when_current_frame_finishes$/;"	f
+test_next_stays_in_current_frame_while_not_finished	test/commands/next_test.rb	/^    def test_next_stays_in_current_frame_while_not_finished$/;"	f
+test_next_steps_over_rescue_when_raising_from_c_method	test/commands/next_test.rb	/^    def test_next_steps_over_rescue_when_raising_from_c_method$/;"	f
+test_next_steps_over_rescue_when_raising_from_ruby_method	test/commands/next_test.rb	/^    def test_next_steps_over_rescue_when_raising_from_ruby_method$/;"	f
+test_next_works_as_expected_with_define_method	test/commands/next_test.rb	/^    def test_next_works_as_expected_with_define_method$/;"	f
+test_next_works_return_inside_loop_inside_initialize	test/commands/next_test.rb	/^    def test_next_works_return_inside_loop_inside_initialize$/;"	f
+test_per_test	test/minitest_runner_test.rb	/^    def test_per_test$/;"	f	class:Byebug.MinitestRunnerTest
+test_per_test_class	test/minitest_runner_test.rb	/^    def test_per_test_class$/;"	f	class:Byebug.MinitestRunnerTest
+test_post_mortem_mode_sets_post_mortem_flag_to_true	test/post_mortem_test.rb	/^    def test_post_mortem_mode_sets_post_mortem_flag_to_true$/;"	f
+test_print_collection	test/printers/plain_test.rb	/^    def test_print_collection$/;"	f	class:Byebug.PrintersPlainTest
+test_print_variables	test/printers/plain_test.rb	/^    def test_print_variables$/;"	f	class:Byebug.PrintersPlainTest
+test_properly_evaluates_expressions_using_threads	test/processors/command_processor_test.rb	/^    def test_properly_evaluates_expressions_using_threads$/;"	f
+test_pry_command_starts_a_pry_session_if_pry_installed	test/commands/pry_test.rb	/^    def test_pry_command_starts_a_pry_session_if_pry_installed$/;"	f	class:Byebug
+test_quit_finishes_byebug_if_user_confirms	test/commands/quit_test.rb	/^    def test_quit_finishes_byebug_if_user_confirms$/;"	f	class:Byebug.QuitTest
+test_quit_quits_inmediately_if_used_with_bang	test/commands/quit_test.rb	/^    def test_quit_quits_inmediately_if_used_with_bang$/;"	f	class:Byebug.QuitTest
+test_quit_quits_inmediately_if_used_with_unconditionally	test/commands/quit_test.rb	/^    def test_quit_quits_inmediately_if_used_with_unconditionally$/;"	f	class:Byebug.QuitTest
+test_rc_file_commands_are_properly_run_by_default	test/rc_test.rb	/^    def test_rc_file_commands_are_properly_run_by_default$/;"	f	class:Byebug
+test_rc_file_commands_are_properly_run_by_explicit_option	test/rc_test.rb	/^    def test_rc_file_commands_are_properly_run_by_explicit_option$/;"	f	class:Byebug
+test_rc_file_commands_are_properly_run_when_home_folder_not_known	test/rc_test.rb	/^    def test_rc_file_commands_are_properly_run_when_home_folder_not_known$/;"	f	class:Byebug
+test_rc_file_with_invalid_commands	test/rc_test.rb	/^    def test_rc_file_with_invalid_commands$/;"	f	class:Byebug
+test_readline_reads_input_until_first_non_comment	test/interfaces/script_interface_test.rb	/^    def test_readline_reads_input_until_first_non_comment$/;"	f
+test_reads_multiple_commands_in_same_line_separated_by_semicolon	test/interface_test.rb	/^    def test_reads_multiple_commands_in_same_line_separated_by_semicolon$/;"	f	class:Byebug.InterfaceTest
+test_reads_simple_commands	test/interface_test.rb	/^    def test_reads_simple_commands$/;"	f	class:Byebug.InterfaceTest
+test_removes_all_expressions_from_list_if_confirmed	test/commands/undisplay_test.rb	/^    def test_removes_all_expressions_from_list_if_confirmed$/;"	f	class:Byebug
+test_restart_with_args_in_attached_mode	test/commands/restart_test.rb	/^    def test_restart_with_args_in_attached_mode$/;"	f
+test_restart_with_args_in_standalone_mode	test/commands/restart_test.rb	/^    def test_restart_with_args_in_standalone_mode$/;"	f
+test_restart_with_no_args_in_attached_mode	test/commands/restart_test.rb	/^    def test_restart_with_no_args_in_attached_mode$/;"	f
+test_restart_with_no_args_in_standalone_mode	test/commands/restart_test.rb	/^    def test_restart_with_no_args_in_standalone_mode$/;"	f	class:Byebug
+test_restart_with_no_args_original_script_through_ruby_attached_mode	test/commands/restart_test.rb	/^    def test_restart_with_no_args_original_script_through_ruby_attached_mode$/;"	f	class:Byebug.RestartTest
+test_restart_with_no_args_original_script_with_no_args_attached_mode	test/commands/restart_test.rb	/^    def test_restart_with_no_args_original_script_with_no_args_attached_mode$/;"	f	class:Byebug.RestartTest
+test_restart_with_no_args_original_script_with_no_args_standalone_mode	test/commands/restart_test.rb	/^    def test_restart_with_no_args_original_script_with_no_args_standalone_mode$/;"	f	class:Byebug.RestartTest
+test_restores_previous_autolisting_after_skip	test/commands/skip_test.rb	/^    def test_restores_previous_autolisting_after_skip$/;"	f
+test_returns_correctly_translated_string	test/printers/plain_test.rb	/^    def test_returns_correctly_translated_string$/;"	f	class:Byebug.PrintersPlainTest
+test_rises_before_exit_in_post_mortem_mode	test/post_mortem_test.rb	/^    def test_rises_before_exit_in_post_mortem_mode$/;"	f
+test_ruby_code_is_evaluated_on_unknown_input	test/processors/command_processor_test.rb	/^    def test_ruby_code_is_evaluated_on_unknown_input$/;"	f
+test_run_and_press_tab_doesnt_make_byebug_crash	test/runner_against_valid_program_test.rb	/^    def test_run_and_press_tab_doesnt_make_byebug_crash$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_stops_at_the_first_line_by_default	test/runner_against_valid_program_test.rb	/^    def test_run_stops_at_the_first_line_by_default$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_a_script_and_params_does_not_consume_script_params	test/runner_against_valid_program_test.rb	/^    def test_run_with_a_script_and_params_does_not_consume_script_params$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_a_script_to_debug	test/runner_against_program_with_byebug_call_test.rb	/^    def test_run_with_a_script_to_debug$/;"	f	class:Byebug.RunnerAgainstProgramWithByebugCallTest
+test_run_with_a_script_to_debug	test/runner_against_valid_program_test.rb	/^    def test_run_with_a_script_to_debug$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_a_single_include_flag	test/runner_against_valid_program_test.rb	/^    def test_run_with_a_single_include_flag$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_an_invalid_script	test/runner_without_target_program_test.rb	/^    def test_run_with_an_invalid_script$/;"	f	class:Byebug.RunnerWithoutTargetProgramTest
+test_run_with_an_nonexistent_script	test/runner_without_target_program_test.rb	/^    def test_run_with_an_nonexistent_script$/;"	f	class:Byebug.RunnerWithoutTargetProgramTest
+test_run_with_debug_flag	test/runner_against_valid_program_test.rb	/^    def test_run_with_debug_flag$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_fullpath_ruby_is_ignored_and_script_passed_instead	test/runner_against_valid_program_test.rb	/^    def test_run_with_fullpath_ruby_is_ignored_and_script_passed_instead$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_help_flag	test/runner_without_target_program_test.rb	/^    def test_run_with_help_flag$/;"	f	class:Byebug.RunnerWithoutTargetProgramTest
+test_run_with_linetracing_flag	test/runner_against_valid_program_test.rb	/^    def test_run_with_linetracing_flag$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_no_quit_flag	test/runner_against_valid_program_test.rb	/^    def test_run_with_no_quit_flag$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_no_rc_option	test/rc_test.rb	/^    def test_run_with_no_rc_option$/;"	f	class:Byebug.RcTest
+test_run_with_no_stop_flag_does_not_stop_at_the_first_line	test/runner_against_valid_program_test.rb	/^    def test_run_with_no_stop_flag_does_not_stop_at_the_first_line$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_post_mortem_mode_flag	test/runner_against_valid_program_test.rb	/^    def test_run_with_post_mortem_mode_flag$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_remote_option_only_with_a_port_number	test/runner_without_target_program_test.rb	/^    def test_run_with_remote_option_only_with_a_port_number$/;"	f	class:Byebug.RunnerWithoutTargetProgramTest
+test_run_with_remote_option_with_host_and_port_specification	test/runner_without_target_program_test.rb	/^    def test_run_with_remote_option_with_host_and_port_specification$/;"	f	class:Byebug.RunnerWithoutTargetProgramTest
+test_run_with_require_flag	test/runner_against_valid_program_test.rb	/^    def test_run_with_require_flag$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_ruby_is_ignored_and_script_passed_instead	test/runner_against_valid_program_test.rb	/^    def test_run_with_ruby_is_ignored_and_script_passed_instead$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_several_include_flags	test/runner_against_valid_program_test.rb	/^    def test_run_with_several_include_flags$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_stop_flag_stops_at_the_first_line	test/runner_against_valid_program_test.rb	/^    def test_run_with_stop_flag_stops_at_the_first_line$/;"	f	class:Byebug.RunnerAgainstValidProgramTest
+test_run_with_version_flag	test/runner_without_target_program_test.rb	/^    def test_run_with_version_flag$/;"	f	class:Byebug.RunnerWithoutTargetProgramTest
+test_run_without_a_script_to_debug	test/runner_without_target_program_test.rb	/^    def test_run_without_a_script_to_debug$/;"	f	class:Byebug.RunnerWithoutTargetProgramTest
+test_runs	test/minitest_runner_test.rb	/^    def test_runs$/;"	f	class:Byebug.MinitestRunnerTest
+test_s_goes_to_the_next_statement	test/commands/step_test.rb	/^    def test_s_goes_to_the_next_statement$/;"	f
+test_save_records_catchpoints	test/commands/save_test.rb	/^    def test_save_records_catchpoints$/;"	f	class:Byebug
+test_save_records_conditional_breakpoints	test/commands/save_test.rb	/^    def test_save_records_conditional_breakpoints$/;"	f	class:Byebug
+test_save_records_current_state_of_settings	test/commands/save_test.rb	/^    def test_save_records_current_state_of_settings$/;"	f	class:Byebug
+test_save_records_displays	test/commands/save_test.rb	/^    def test_save_records_displays$/;"	f	class:Byebug
+test_save_records_regular_breakpoints	test/commands/save_test.rb	/^    def test_save_records_regular_breakpoints$/;"	f	class:Byebug
+test_save_shows_a_success_message	test/commands/save_test.rb	/^    def test_save_shows_a_success_message$/;"	f	class:Byebug
+test_save_without_a_filename_shows_a_message_with_the_file_used	test/commands/save_test.rb	/^    def test_save_without_a_filename_shows_a_message_with_the_file_used$/;"	f	class:Byebug
+test_save_without_a_filename_uses_a_default_file	test/commands/save_test.rb	/^    def test_save_without_a_filename_uses_a_default_file$/;"	f	class:Byebug
+test_saves_displayed_expressions	test/commands/display_test.rb	/^    def test_saves_displayed_expressions$/;"	f	class:Byebug
+test_script_processor_clears_history	test/processors/script_processor_test.rb	/^    def test_script_processor_clears_history$/;"	f	class:Byebug.ScriptProcessorTest
+test_script_processor_closes_files	test/processors/script_processor_test.rb	/^    def test_script_processor_closes_files$/;"	f	class:Byebug.ScriptProcessorTest
+test_semicolon_can_be_escaped_to_prevent_multiple_command_behaviour	test/processors/command_processor_test.rb	/^    def test_semicolon_can_be_escaped_to_prevent_multiple_command_behaviour$/;"	f	class:Byebug
+test_set_does_not_disable_a_setting_using_shorcut_when_ambiguous	test/commands/set_test.rb	/^    def test_set_does_not_disable_a_setting_using_shorcut_when_ambiguous$/;"	f
+test_set_does_not_enable_a_setting_using_shorcut_when_ambiguous	test/commands/set_test.rb	/^    def test_set_does_not_enable_a_setting_using_shorcut_when_ambiguous$/;"	f
+test_set_enables_a_setting_using_shorcut_when_not_ambiguous	test/commands/set_test.rb	/^    def test_set_enables_a_setting_using_shorcut_when_not_ambiguous$/;"	f
+test_set_histfile_sets_command_history_file	test/commands/set_test.rb	/^    def test_set_histfile_sets_command_history_file$/;"	f
+test_set_histfile_shows_an_error_message_if_no_filename_is_provided	test/commands/set_test.rb	/^    def test_set_histfile_shows_an_error_message_if_no_filename_is_provided$/;"	f
+test_set_histsize_sets_maximum_history_size	test/commands/set_test.rb	/^    def test_set_histsize_sets_maximum_history_size$/;"	f
+test_set_histsize_shows_an_error_message_if_no_size_is_provided	test/commands/set_test.rb	/^    def test_set_histsize_shows_an_error_message_if_no_size_is_provided$/;"	f
+test_set_linetrace_enables_tracing_program_execution	test/commands/set_test.rb	/^    def test_set_linetrace_enables_tracing_program_execution$/;"	f
+test_set_nolinetrace_stops_tracing_program_execution	test/commands/set_test.rb	/^    def test_set_nolinetrace_stops_tracing_program_execution$/;"	f
+test_set_without_arguments_shows_help_for_set_command	test/commands/set_test.rb	/^    def test_set_without_arguments_shows_help_for_set_command$/;"	f
+test_setting_breakpoint_prints_confirmation_message	test/commands/break_test.rb	/^    def test_setting_breakpoint_prints_confirmation_message$/;"	f
+test_setting_breakpoint_sets_correct_fields	test/commands/break_test.rb	/^    def test_setting_breakpoint_sets_correct_fields$/;"	f
+test_setting_breakpoint_to_an_undefined_class_creates_breakpoint	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_an_undefined_class_creates_breakpoint$/;"	f
+test_setting_breakpoint_to_an_undefined_class_shows_error_message	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_an_undefined_class_shows_error_message$/;"	f
+test_setting_breakpoint_to_invalid_line_does_not_create_breakpoint	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_invalid_line_does_not_create_breakpoint$/;"	f
+test_setting_breakpoint_to_invalid_line_shows_an_error_and_alternatives	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_invalid_line_shows_an_error_and_alternatives$/;"	f
+test_setting_breakpoint_to_invalid_location_does_not_create_breakpoint	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_invalid_location_does_not_create_breakpoint$/;"	f
+test_setting_breakpoint_to_invalid_location_shows_an_error	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_invalid_location_shows_an_error$/;"	f
+test_setting_breakpoint_to_nonexistent_file_does_not_create_breakpoint	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_nonexistent_file_does_not_create_breakpoint$/;"	f
+test_setting_breakpoint_to_nonexistent_file_shows_an_error	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_nonexistent_file_shows_an_error$/;"	f
+test_setting_breakpoint_to_nonexistent_file_with_space_shows_an_error	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_nonexistent_file_with_space_shows_an_error$/;"	f
+test_setting_breakpoint_to_nonexistent_line_does_not_create_breakpoint	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_nonexistent_line_does_not_create_breakpoint$/;"	f
+test_setting_breakpoint_to_nonexistent_line_shows_an_error	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_nonexistent_line_shows_an_error$/;"	f
+test_setting_breakpoint_to_path_with_colons_does_not_crash	test/commands/break_test.rb	/^    def test_setting_breakpoint_to_path_with_colons_does_not_crash$/;"	f
+test_setting_breakpoint_uses_new_source	test/commands/break_test.rb	/^    def test_setting_breakpoint_uses_new_source$/;"	f
+test_setting_breakpoint_using_shortcut_properly_adds_the_breakpoint	test/commands/break_test.rb	/^    def test_setting_breakpoint_using_shortcut_properly_adds_the_breakpoint$/;"	f
+test_setting_breakpoint_with_bad_relative_path_doesnt_crash	test/commands/break_test.rb	/^    def test_setting_breakpoint_with_bad_relative_path_doesnt_crash$/;"	f
+test_setting_breakpoint_with_relative_path_adds_the_breakpoint	test/commands/break_test.rb	/^    def test_setting_breakpoint_with_relative_path_adds_the_breakpoint$/;"	f
+test_setting_breakpoint_with_space_in_path_adds_the_breakpoint	test/commands/break_test.rb	/^    def test_setting_breakpoint_with_space_in_path_adds_the_breakpoint$/;"	f
+test_setting_condition_assigns_expression_to_breakpoint	test/commands/condition_test.rb	/^    def test_setting_condition_assigns_expression_to_breakpoint$/;"	f	class:Byebug
+test_setting_condition_w_wrong_syntax_does_not_enable_breakpoint	test/commands/condition_test.rb	/^    def test_setting_condition_w_wrong_syntax_does_not_enable_breakpoint$/;"	f	class:Byebug
+test_setting_condition_w_wrong_syntax_shows_error	test/commands/condition_test.rb	/^    def test_setting_condition_w_wrong_syntax_shows_error$/;"	f	class:Byebug
+test_setting_conditional_breakpoint_using_wrong_expression_ignores_it	test/commands/break_test.rb	/^    def test_setting_conditional_breakpoint_using_wrong_expression_ignores_it$/;"	f
+test_setting_conditional_breakpoint_using_wrong_expression_shows_error	test/commands/break_test.rb	/^    def test_setting_conditional_breakpoint_using_wrong_expression_shows_error$/;"	f
+test_show_callstyle	test/commands/show_test.rb	/^    def test_show_callstyle$/;"	f
+test_show_histfile	test/commands/show_test.rb	/^    def test_show_histfile$/;"	f
+test_show_histsize	test/commands/show_test.rb	/^    def test_show_histsize$/;"	f
+test_show_listsize	test/commands/show_test.rb	/^    def test_show_listsize$/;"	f
+test_show_unknown_setting	test/commands/show_test.rb	/^    def test_show_unknown_setting$/;"	f
+test_show_width	test/commands/show_test.rb	/^    def test_show_width$/;"	f
+test_show_without_arguments_displays_help_for_the_show_command	test/commands/show_test.rb	/^    def test_show_without_arguments_displays_help_for_the_show_command$/;"	f
+test_shows_an_error_for_unknown_subcommands_by_default	test/processors/command_processor_test.rb	/^    def test_shows_an_error_for_unknown_subcommands_by_default$/;"	f	class:Byebug
+test_shows_backtrace_on_error_if_stack_on_error_enabled	test/processors/command_processor_test.rb	/^    def test_shows_backtrace_on_error_if_stack_on_error_enabled$/;"	f
+test_shows_error_if_breakpoint_id_is_incorrect	test/commands/condition_test.rb	/^    def test_shows_error_if_breakpoint_id_is_incorrect$/;"	f	class:Byebug
+test_shows_error_if_specified_line_is_not_valid	test/commands/continue_test.rb	/^    def test_shows_error_if_specified_line_is_not_valid$/;"	f
+test_shows_error_if_there_are_no_breakpoints	test/commands/condition_test.rb	/^    def test_shows_error_if_there_are_no_breakpoints$/;"	f	class:Byebug
+test_shows_error_when_current_source_location_is_unknown	test/processors/command_processor_test.rb	/^    def test_shows_error_when_current_source_location_is_unknown$/;"	f
+test_shows_error_when_invoked_with_invalid_syntax	test/commands/list_test.rb	/^    def test_shows_error_when_invoked_with_invalid_syntax$/;"	f
+test_shows_expressions	test/commands/display_test.rb	/^    def test_shows_expressions$/;"	f	class:Byebug
+test_shows_info_about_setting_breakpoints_when_using_just_break	test/commands/break_test.rb	/^    def test_shows_info_about_setting_breakpoints_when_using_just_break$/;"	f
+test_shows_nil_return_value	test/commands/break_test.rb	/^    def test_shows_nil_return_value$/;"	f
+test_shows_only_exception_if_stack_on_error_disabled	test/processors/command_processor_test.rb	/^    def test_shows_only_exception_if_stack_on_error_disabled$/;"	f
+test_shows_return_value_information_when_breakpoint_set_at_method_return	test/commands/break_test.rb	/^    def test_shows_return_value_information_when_breakpoint_set_at_method_return$/;"	f
+test_shows_undefined_expressions	test/commands/display_test.rb	/^    def test_shows_undefined_expressions$/;"	f	class:Byebug
+test_source_runs_byebug_commands_from_file	test/commands/source_test.rb	/^    def test_source_runs_byebug_commands_from_file$/;"	f
+test_source_shows_an_error_if_file_not_found	test/commands/source_test.rb	/^    def test_source_shows_an_error_if_file_not_found$/;"	f
+test_source_without_arguments_shows_help	test/commands/source_test.rb	/^    def test_source_without_arguments_shows_help$/;"	f
+test_step_goes_to_the_next_statement	test/commands/step_test.rb	/^    def test_step_goes_to_the_next_statement$/;"	f
+test_step_then_up_then_next_advances_in_the_upper_frame	test/commands/next_test.rb	/^    def test_step_then_up_then_next_advances_in_the_upper_frame$/;"	f
+test_step_then_up_then_steps_in_from_the_upper_frame	test/commands/step_test.rb	/^    def test_step_then_up_then_steps_in_from_the_upper_frame$/;"	f
+test_stops_at_correct_place_when_breakpoint_set_at_method_return	test/commands/break_test.rb	/^    def test_stops_at_correct_place_when_breakpoint_set_at_method_return$/;"	f
+test_stops_at_correct_place_when_breakpoint_set_in_a_regular_line	test/commands/break_test.rb	/^    def test_stops_at_correct_place_when_breakpoint_set_in_a_regular_line$/;"	f
+test_stops_byebug_after_continue	test/commands/continue_test.rb	/^    def test_stops_byebug_after_continue$/;"	f
+test_stops_right_before_block_returns	test/commands/break_test.rb	/^    def test_stops_right_before_block_returns$/;"	f
+test_stops_right_before_class_definition_ends	test/commands/break_test.rb	/^    def test_stops_right_before_class_definition_ends$/;"	f
+test_stops_right_before_method_returns	test/commands/break_test.rb	/^    def test_stops_right_before_method_returns$/;"	f
+test_strings_inherited_from_base	test/printers/plain_test.rb	/^    def test_strings_inherited_from_base$/;"	f	class:Byebug.PrintersPlainTest
+test_subdebugger_goes_back_to_previous_debugger_after_continue	test/commands/debug_test.rb	/^    def test_subdebugger_goes_back_to_previous_debugger_after_continue$/;"	f
+test_subdebugger_stops_at_correct_point_when_invoked_from_breakpoint	test/commands/debug_test.rb	/^    def test_subdebugger_stops_at_correct_point_when_invoked_from_breakpoint$/;"	f
+test_subdebugger_stops_at_correct_point_when_invoked_through_byebug_call	test/commands/debug_test.rb	/^    def test_subdebugger_stops_at_correct_point_when_invoked_through_byebug_call$/;"	f
+test_suite?	test/minitest_runner.rb	/^    def test_suite?(str)$/;"	f	class:Byebug
+test_suites	test/minitest_runner.rb	/^    def test_suites$/;"	f	class:Byebug
+test_syntax_error_gives_a_prompt_back	test/processors/command_processor_test.rb	/^    def test_syntax_error_gives_a_prompt_back$/;"	f	class:Byebug
+test_thread_context_is_kept	test/processors/command_processor_test.rb	/^    def test_thread_context_is_kept$/;"	f
+test_thread_list_marks_current_thread_with_a_plus_sign	test/commands/thread_test.rb	/^    def test_thread_list_marks_current_thread_with_a_plus_sign$/;"	f
+test_thread_list_shows_all_available_threads	test/commands/thread_test.rb	/^    def test_thread_list_shows_all_available_threads$/;"	f
+test_thread_resume_removes_threads_from_the_suspended_state	test/commands/thread_test.rb	/^    def test_thread_resume_removes_threads_from_the_suspended_state$/;"	f
+test_thread_resume_shows_error_if_thread_is_already_running	test/commands/thread_test.rb	/^    def test_thread_resume_shows_error_if_thread_is_already_running$/;"	f
+test_thread_resume_shows_error_when_trying_to_resume_current_thread	test/commands/thread_test.rb	/^    def test_thread_resume_shows_error_when_trying_to_resume_current_thread$/;"	f
+test_thread_resume_shows_help_if_thread_number_not_specified	test/commands/thread_test.rb	/^    def test_thread_resume_shows_help_if_thread_number_not_specified$/;"	f
+test_thread_stop_actually_suspends_thread_execution	test/commands/thread_test.rb	/^    def test_thread_stop_actually_suspends_thread_execution$/;"	f
+test_thread_stop_marks_thread_as_suspended	test/commands/thread_test.rb	/^    def test_thread_stop_marks_thread_as_suspended$/;"	f
+test_thread_stop_shows_error_when_trying_to_stop_current_thread	test/commands/thread_test.rb	/^    def test_thread_stop_shows_error_when_trying_to_stop_current_thread$/;"	f
+test_thread_stop_shows_help_when_no_thread_number_specified	test/commands/thread_test.rb	/^    def test_thread_stop_shows_help_when_no_thread_number_specified$/;"	f
+test_thread_switch_changes_execution_to_another_thread	test/commands/thread_test.rb	/^    def test_thread_switch_changes_execution_to_another_thread$/;"	f
+test_thread_switch_shows_error_when_trying_to_switch_current_thread	test/commands/thread_test.rb	/^    def test_thread_switch_shows_error_when_trying_to_switch_current_thread$/;"	f
+test_thread_switch_shows_help_if_thread_number_not_specified	test/commands/thread_test.rb	/^    def test_thread_switch_shows_help_if_thread_number_not_specified$/;"	f
+test_top_level_b_call_event	test/commands/next_test.rb	/^    def test_top_level_b_call_event$/;"	f	class:TopLevelBlockEventsTest
+test_tracevar_nostop_does_not_stop_when_global_var_changes	test/commands/tracevar_test.rb	/^    def test_tracevar_nostop_does_not_stop_when_global_var_changes$/;"	f
+test_tracevar_shows_an_error_message_if_no_global_variable_is_specified	test/commands/tracevar_test.rb	/^    def test_tracevar_shows_an_error_message_if_no_global_variable_is_specified$/;"	f
+test_tracevar_shows_an_error_message_if_there_is_no_such_global_var	test/commands/tracevar_test.rb	/^    def test_tracevar_shows_an_error_message_if_there_is_no_such_global_var$/;"	f
+test_tracevar_stop_makes_program_stop_when_global_var_changes	test/commands/tracevar_test.rb	/^    def test_tracevar_stop_makes_program_stop_when_global_var_changes$/;"	f
+test_tracevar_tracks_global_variables	test/commands/tracevar_test.rb	/^    def test_tracevar_tracks_global_variables$/;"	f
+test_tracing_after_set_linetrace_and_continue	test/commands/continue_test.rb	/^    def test_tracing_after_set_linetrace_and_continue$/;"	f
+test_understands_ruby_commands_using_semicolon_if_escaped	test/interface_test.rb	/^    def test_understands_ruby_commands_using_semicolon_if_escaped$/;"	f	class:Byebug.InterfaceTest
+test_up_autolists_new_source_location_when_autolist_enabled	test/commands/up_test.rb	/^    def test_up_autolists_new_source_location_when_autolist_enabled$/;"	f
+test_up_does_not_autolist_new_source_location_when_autolist_disabled	test/commands/up_test.rb	/^    def test_up_does_not_autolist_new_source_location_when_autolist_disabled$/;"	f
+test_up_does_not_move_if_frame_number_to_too_high	test/commands/up_test.rb	/^    def test_up_does_not_move_if_frame_number_to_too_high$/;"	f
+test_up_moves_up_in_the_callstack	test/commands/up_test.rb	/^    def test_up_moves_up_in_the_callstack$/;"	f
+test_up_moves_up_in_the_callstack_a_specific_number_of_frames	test/commands/up_test.rb	/^    def test_up_moves_up_in_the_callstack_a_specific_number_of_frames$/;"	f
+test_up_plays_well_with_evaluation	test/commands/up_test.rb	/^    def test_up_plays_well_with_evaluation$/;"	f
+test_up_skips_c_frames	test/commands/up_test.rb	/^    def test_up_skips_c_frames$/;"	f
+test_var_all_shows_all_variables	test/commands/var_test.rb	/^    def test_var_all_shows_all_variables$/;"	f
+test_var_args_shows_information_about_current_frame_arguments	test/commands/var_test.rb	/^    def test_var_args_shows_information_about_current_frame_arguments$/;"	f
+test_var_const_shows_constants_in_class_or_module	test/commands/var_test.rb	/^    def test_var_const_shows_constants_in_class_or_module$/;"	f
+test_var_const_shows_constants_in_current_scope_when_without_argument	test/commands/var_test.rb	/^    def test_var_const_shows_constants_in_current_scope_when_without_argument$/;"	f
+test_var_const_shows_error_if_given_object_is_not_a_class_or_module	test/commands/var_test.rb	/^    def test_var_const_shows_error_if_given_object_is_not_a_class_or_module$/;"	f
+test_var_global_shows_global_variables	test/commands/var_test.rb	/^    def test_var_global_shows_global_variables$/;"	f
+test_var_instance_cuts_long_variable_values_according_to_width_setting	test/commands/var_test.rb	/^    def test_var_instance_cuts_long_variable_values_according_to_width_setting$/;"	f
+test_var_instance_shows_instance_variables_of_self_if_no_object_given	test/commands/var_test.rb	/^    def test_var_instance_shows_instance_variables_of_self_if_no_object_given$/;"	f
+test_var_instance_shows_instance_vars_of_an_object	test/commands/var_test.rb	/^    def test_var_instance_shows_instance_vars_of_an_object$/;"	f
+test_var_local_shows_local_variables	test/commands/var_test.rb	/^    def test_var_local_shows_local_variables$/;"	f
+test_where_displays_backtraces_using_long_callstyle_by_default	test/commands/where_test.rb	/^    def test_where_displays_backtraces_using_long_callstyle_by_default$/;"	f
+test_where_displays_backtraces_using_short_callstyle	test/commands/where_test.rb	/^    def test_where_displays_backtraces_using_short_callstyle$/;"	f
+test_where_displays_current_backtrace_w_shorpaths_if_fullpath_disabled	test/commands/where_test.rb	/^      def test_where_displays_current_backtrace_w_shorpaths_if_fullpath_disabled$/;"	f	class:WhereWithNotDeeplyNestedPathsTest
+test_where_displays_current_backtrace_w_shorpaths_if_fullpath_disabled	test/commands/where_test.rb	/^    def test_where_displays_current_backtrace_w_shorpaths_if_fullpath_disabled$/;"	f	class:WhereWithDeeplyNestedPathsTest
+test_where_displays_current_backtrace_with_fullpaths_by_default	test/commands/where_test.rb	/^    def test_where_displays_current_backtrace_with_fullpaths_by_default$/;"	f
+test_where_displays_instance_exec_block_frames	test/commands/where_test.rb	/^    def test_where_displays_instance_exec_block_frames$/;"	f
+test_which_resolves_ruby	test/helpers/bin_helper_test.rb	/^      def test_which_resolves_ruby$/;"	f	class:Byebug.Helpers.BinHelperTest
+test_with_seed_option	test/minitest_runner_test.rb	/^    def test_with_seed_option$/;"	f	class:Byebug.MinitestRunnerTest
+test_with_verbose_option	test/minitest_runner_test.rb	/^    def test_with_verbose_option$/;"	f	class:Byebug.MinitestRunnerTest
+test_works_in_abbreviated_mode_too	test/commands/continue_test.rb	/^    def test_works_in_abbreviated_mode_too$/;"	f
+test_works_in_abbreviated_mode_too	test/commands/skip_test.rb	/^    def test_works_in_abbreviated_mode_too$/;"	f
+thnum	ext/byebug/byebug.h	/^  int thnum;$/;"	m	struct:__anon2	access:public
+thnum_max	ext/byebug/context.c	/^static int thnum_max = 0;$/;"	v	file:
+thread	ext/byebug/byebug.h	/^  VALUE thread;$/;"	m	struct:__anon2	access:public
+thread	ext/byebug/locker.c	/^  VALUE thread;$/;"	m	struct:locked_thread_t	file:	access:public
+thread.rb	lib/byebug/commands/thread.rb	1;"	F
+thread.rb	lib/byebug/helpers/thread.rb	1;"	F
+thread_arguments	lib/byebug/helpers/thread.rb	/^      def thread_arguments(ctx)$/;"	f	class:Byebug.Helpers.ThreadHelper
+thread_context_lookup	ext/byebug/byebug.h	/^extern void thread_context_lookup(VALUE thread, VALUE *context);$/;"	p	signature:(VALUE thread, VALUE *context)
+thread_context_lookup	ext/byebug/threads.c	/^thread_context_lookup(VALUE thread, VALUE *context)$/;"	f	signature:(VALUE thread, VALUE *context)
+thread_test.rb	test/commands/thread_test.rb	1;"	F
+threads	ext/byebug/byebug.c	/^VALUE threads = Qnil;$/;"	v
+threads.c	ext/byebug/threads.c	1;"	F
+threads_table_t	ext/byebug/byebug.h	/^} threads_table_t;$/;"	t	typeref:struct:__anon4
+to_hash	lib/byebug/frame.rb	/^    def to_hash$/;"	f	class:Byebug.Frame
+to_s	lib/byebug/command.rb	/^      def to_s$/;"	f	class:Byebug.Command
+to_s	lib/byebug/command_list.rb	/^    def to_s$/;"	f	class:Byebug.CommandList
+to_s	lib/byebug/history.rb	/^    def to_s(n_cmds)$/;"	f	class:Byebug
+to_s	lib/byebug/setting.rb	/^    def to_s$/;"	f	class:Byebug.Setting
+to_s	lib/byebug/settings/callstyle.rb	/^    def to_s$/;"	f	class:Byebug.CallstyleSetting
+to_s	lib/byebug/settings/histfile.rb	/^    def to_s$/;"	f	class:Byebug.HistfileSetting
+to_s	lib/byebug/settings/histsize.rb	/^    def to_s$/;"	f	class:Byebug.HistsizeSetting
+to_s	lib/byebug/settings/listsize.rb	/^    def to_s$/;"	f	class:Byebug.ListsizeSetting
+to_s	lib/byebug/settings/savefile.rb	/^    def to_s$/;"	f	class:Byebug.SavefileSetting
+to_s	lib/byebug/settings/width.rb	/^    def to_s$/;"	f	class:Byebug.WidthSetting
+to_sym	lib/byebug/setting.rb	/^    def to_sym$/;"	f	class:Byebug.Setting
+toggle.rb	lib/byebug/helpers/toggle.rb	1;"	F
+trace	lib/byebug/option_setter.rb	/^    def trace$/;"	f
+trace_print	ext/byebug/byebug.c	/^trace_print(rb_trace_arg_t *trace_arg, debug_context_t *dc,$/;"	f	file:	signature:(rb_trace_arg_t *trace_arg, debug_context_t *dc, const char *file_filter, const char *debug_msg)
+tracepoints	ext/byebug/byebug.c	/^static VALUE tracepoints = Qnil;$/;"	v	file:
+tracevar.rb	lib/byebug/commands/tracevar.rb	1;"	F
+tracevar_test.rb	test/commands/tracevar_test.rb	1;"	F
+tracing	ext/byebug/byebug.c	/^static VALUE tracing = Qfalse;$/;"	v	file:
+translate	lib/byebug/printers/base.rb	/^      def translate(string, args = {})$/;"	f	class:Byebug.Printers.Base
+type	ext/byebug/byebug.h	/^  enum bp_type type;$/;"	m	struct:__anon5	typeref:enum:__anon5::bp_type	access:public
+type	lib/byebug/printers/base.rb	/^      def type$/;"	f	class:Byebug.Printers.Base
+unconditionally?	lib/byebug/commands/continue.rb	/^    def unconditionally?$/;"	f	class:Byebug.ContinueCommand
+undisplay.rb	lib/byebug/commands/undisplay.rb	1;"	F
+undisplay_test.rb	test/commands/undisplay_test.rb	1;"	F
+until_line?	lib/byebug/commands/continue.rb	/^    def until_line?$/;"	f	class:Byebug.ContinueCommand
+untracevar.rb	lib/byebug/commands/untracevar.rb	1;"	F
+up.rb	lib/byebug/commands/up.rb	1;"	F
+up_test.rb	test/commands/up_test.rb	1;"	F
+upper_bound	lib/byebug/commands/list.rb	/^    def upper_bound(range)$/;"	f	class:Byebug.ListCommand
+use_short_style?	lib/byebug/frame.rb	/^    def use_short_style?(arg)$/;"	f	class:Byebug.Frame
+utils.rb	test/support/utils.rb	1;"	F
+valid_breakpoints_for	lib/byebug/commands/break.rb	/^    def valid_breakpoints_for(path, line)$/;"	f	class:Byebug.BreakCommand
+valid_range?	lib/byebug/commands/list.rb	/^    def valid_range?(first, last)$/;"	f	class:Byebug.ListCommand
+value	lib/byebug/settings/autoirb.rb	/^    def value$/;"	f	class:Byebug.AutoirbSetting
+value	lib/byebug/settings/autolist.rb	/^    def value$/;"	f	class:Byebug.AutolistSetting
+value	lib/byebug/settings/autopry.rb	/^    def value$/;"	f	class:Byebug.AutoprySetting
+value	lib/byebug/settings/linetrace.rb	/^    def value$/;"	f	class:Byebug.LinetraceSetting
+value	lib/byebug/settings/post_mortem.rb	/^    def value$/;"	f	class:Byebug.PostMortemSetting
+value=	lib/byebug/settings/autoirb.rb	/^    def value=(val)$/;"	f	class:Byebug.AutoirbSetting
+value=	lib/byebug/settings/autolist.rb	/^    def value=(val)$/;"	f	class:Byebug.AutolistSetting
+value=	lib/byebug/settings/autopry.rb	/^    def value=(val)$/;"	f	class:Byebug.AutoprySetting
+value=	lib/byebug/settings/linetrace.rb	/^    def value=(val)$/;"	f	class:Byebug.LinetraceSetting
+value=	lib/byebug/settings/post_mortem.rb	/^    def value=(val)$/;"	f	class:Byebug.PostMortemSetting
+var.rb	lib/byebug/commands/var.rb	1;"	F
+var.rb	lib/byebug/helpers/var.rb	1;"	F
+var_args	lib/byebug/helpers/var.rb	/^      def var_args$/;"	f	class:Byebug.Helpers.VarHelper
+var_global	lib/byebug/helpers/var.rb	/^      def var_global$/;"	f	class:Byebug.Helpers.VarHelper
+var_instance	lib/byebug/helpers/var.rb	/^      def var_instance(str)$/;"	f	class:Byebug.Helpers.VarHelper
+var_list	lib/byebug/helpers/var.rb	/^      def var_list(ary, binding = context.frame._binding)$/;"	f	class:Byebug.Helpers.VarHelper
+var_local	lib/byebug/helpers/var.rb	/^      def var_local$/;"	f	class:Byebug.Helpers.VarHelper
+var_test.rb	test/commands/var_test.rb	1;"	F
+verbose	ext/byebug/byebug.c	/^static VALUE verbose = Qfalse;$/;"	v	file:
+version	lib/byebug/option_setter.rb	/^    def version$/;"	f
+version.rb	lib/byebug/version.rb	1;"	F
+version=	lib/byebug/runner.rb	/^    def version=(number)$/;"	f	class:Byebug.Runner
+virtual_file?	lib/byebug/helpers/file.rb	/^      def virtual_file?(name)$/;"	f	class:Byebug.Helpers.FileHelper
+wait_for_client_startup	test/support/remote_debugging_tests.rb	/^    def wait_for_client_startup$/;"	f	class:Byebug
+warning_eval	lib/byebug/helpers/eval.rb	/^      def warning_eval(str, binding = frame._binding)$/;"	f	class:Byebug.Helpers.EvalHelper
+warning_msg	lib/byebug/helpers/eval.rb	/^      def warning_msg(exception)$/;"	f	class:Byebug.Helpers.EvalHelper
+where.rb	lib/byebug/commands/where.rb	1;"	F
+where_test.rb	test/commands/where_test.rb	1;"	F
+which	lib/byebug/helpers/bin.rb	/^      def which(cmd)$/;"	f	class:Byebug.Helpers.BinHelper
+width	lib/byebug/command_list.rb	/^    def width$/;"	f	class:Byebug.CommandList
+width.rb	lib/byebug/settings/width.rb	1;"	F
+with_clean_argv	lib/byebug/commands/irb.rb	/^    def with_clean_argv$/;"	f	class:Byebug.IrbCommand
+with_command_line	test/support/temporary.rb	/^    def with_command_line(program_name, *args)$/;"	f	class:Byebug.TestTemporary
+with_dummy_yaml	test/printers/plain_test.rb	/^    def with_dummy_yaml$/;"	f	class:Byebug.PrintersPlainTest
+with_env	test/support/temporary.rb	/^    def with_env(key, value)$/;"	f	class:Byebug
+with_init_file	test/support/temporary.rb	/^    def with_init_file(content)$/;"	f	class:Byebug.TestTemporary
+with_mode	test/support/temporary.rb	/^    def with_mode(mode)$/;"	f	class:Byebug.TestTemporary
+with_new_file	test/support/temporary.rb	/^    def with_new_file(name, content)$/;"	f	class:Byebug
+with_new_tempfile	test/support/temporary.rb	/^    def with_new_tempfile(content)$/;"	f	class:Byebug.TestTemporary
+with_post_mortem_processor	test/post_mortem_test.rb	/^    def with_post_mortem_processor$/;"	f
+with_repl_like_sigint	lib/byebug/interfaces/local_interface.rb	/^    def with_repl_like_sigint$/;"	f	class:Byebug.LocalInterface
+with_setting	test/support/temporary.rb	/^    def with_setting(key, value)$/;"	f	class:Byebug.TestTemporary
+without_exceptions	lib/byebug/processors/script_processor.rb	/^    def without_exceptions$/;"	f	class:Byebug.ScriptProcessor
+without_readline_completion	lib/byebug/interfaces/local_interface.rb	/^    def without_readline_completion$/;"	f	class:Byebug.LocalInterface
+without_stderr	lib/byebug/helpers/parse.rb	/^      def without_stderr$/;"	f	class:Byebug.Helpers.ParseHelper
+write_program	test/support/remote_debugging_tests.rb	/^    def write_program(code)$/;"	f	class:Byebug.RemoteDebuggingTests
+yaml_base	test/printers/plain_test.rb	/^    def yaml_base$/;"	f	class:Byebug.PrintersPlainTest
+yaml_plain	test/printers/plain_test.rb	/^    def yaml_plain$/;"	f	class:Byebug.PrintersPlainTest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* [#657](https://github.com/deivid-rodriguez/byebug/pull/657): crash when hitting \<TAB\> due to IRB completion mechanism included in the default ruby 2.7 version of the `irb` gem ([@terceiro]).
+
 ## [11.1.1] - 2020-01-24
 
 ### Fixed
@@ -911,6 +915,7 @@
 [@sethk]: https://github.com/sethk
 [@shuky19]: https://github.com/shuky19
 [@tacnoman]: https://github.com/tacnoman
+[@terceiro]: https://github.com/terceiro
 [@tzmfreedom]: https://github.com/tzmfreedom
 [@wallace]: https://github.com/wallace
 [@windwiny]: https://github.com/windwiny

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [11.1.3] - 2020-04-23
+
 ### Fixed
 
 * [#674](https://github.com/deivid-rodriguez/byebug/pull/674): crash when using byebug on ruby 2.7.0 on Windows.
@@ -818,7 +820,8 @@
 
 * Initial release.
 
-[Unreleased]: https://github.com/deivid-rodriguez/byebug/compare/v11.1.2...HEAD
+[Unreleased]: https://github.com/deivid-rodriguez/byebug/compare/v11.1.3...HEAD
+[11.1.3]: https://github.com/deivid-rodriguez/byebug/compare/v11.1.2...v11.1.3
 [11.1.2]: https://github.com/deivid-rodriguez/byebug/compare/v11.1.1...v11.1.2
 [11.1.1]: https://github.com/deivid-rodriguez/byebug/compare/v11.1.0...v11.1.1
 [11.1.0]: https://github.com/deivid-rodriguez/byebug/compare/v11.0.1...v11.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* [#674](https://github.com/deivid-rodriguez/byebug/pull/674): crash when using byebug on ruby 2.7.0 on Windows.
+
 ## [11.1.2] - 2020-04-17
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    byebug (11.1.2)
+    byebug (11.1.3)
 
 GEM
   remote: https://rubygems.org/

--- a/README.sergio.md
+++ b/README.sergio.md
@@ -1,0 +1,6 @@
+* to test a file you can use:
+    bundle exec rake test test/commands/break_test.rb
+or as recommended in CONTRIBUTING.md:
+    bin/minitest test/commands/break_test.
+* someday i was testing and everything was working fine, and then all of the sudden bundle stopped working and I could not test anymore.
+  - the solution was to run the command 'bin/rake compile' as recommended in CONTRIBUTING.md

--- a/lib/byebug/interfaces/local_interface.rb
+++ b/lib/byebug/interfaces/local_interface.rb
@@ -53,7 +53,7 @@ module Byebug
       return yield unless orig_completion
 
       begin
-        Readline.completion_proc = nil
+        Readline.completion_proc = ->(_) { nil }
         yield
       ensure
         Readline.completion_proc = orig_completion

--- a/lib/byebug/settings/histfile.rb
+++ b/lib/byebug/settings/histfile.rb
@@ -7,10 +7,10 @@ module Byebug
   # Setting to customize the file where byebug's history is saved.
   #
   class HistfileSetting < Setting
-    DEFAULT = File.expand_path(".byebug_history")
+    DEFAULT = File.expand_path("#{ENV['HOME'] || '.'}/.byebug_history")
 
     def banner
-      "File where cmd history is saved to. Default: ./.byebug_history"
+      "File where command history is saved to. Default: ~/.byebug_history"
     end
 
     def to_s

--- a/lib/byebug/version.rb
+++ b/lib/byebug/version.rb
@@ -4,5 +4,5 @@
 # Reopen main module to define the library version
 #
 module Byebug
-  VERSION = "11.1.2"
+  VERSION = "11.1.3"
 end

--- a/test/runner_against_valid_program_test.rb
+++ b/test/runner_against_valid_program_test.rb
@@ -118,6 +118,15 @@ module Byebug
       assert_match(/Debug flag is true/, stdout)
     end
 
+    def test_run_and_press_tab_doesnt_make_byebug_crash
+      stdout = run_byebug(
+        example_path,
+        input: "\tputs 'Reached here'"
+      )
+
+      assert_match(/Reached here/, stdout)
+    end
+
     def test_run_stops_at_the_first_line_by_default
       stdout = run_byebug(example_path)
 


### PR DESCRIPTION
Put history file in home directory. Instead of having many local
 `./.byebug_history` files, a central `~/.byebug_history` file allows to
 retreive the history independently from the current directory.