### PR TITLE
Add a fallback for syntax_valid? if RubyVM is not defined

### DIFF
--- a/lib/byebug/helpers/parse.rb
+++ b/lib/byebug/helpers/parse.rb
@@ -35,11 +35,18 @@ module Byebug
       def syntax_valid?(code)
         return true unless code
 
-        without_stderr do
-          RubyVM::InstructionSequence.compile(code)
-          true
-        rescue SyntaxError
-          false
+        if defined?(RubyVM::InstructionSequence.compile)
+          without_stderr do
+            RubyVM::InstructionSequence.compile(code)
+            true
+          rescue SyntaxError
+            false
+          end
+        else
+          require "ripper" unless defined?(Ripper)
+          without_stderr do
+            !Ripper.sexp(code).nil?
+          end
         end
       end
 


### PR DESCRIPTION
* Use Ripper as it is a standard library.
* Another possibility would be to use eval() like this:
  ```ruby
  catch(:valid) do
    eval("BEGIN{throw :valid, true}\n#{code}")
    false
  end
  ```
  as done in https://github.com/banister/method_source/blob/836d7047ab/lib/method_source/code_helpers.rb#L66-L80
  But that means creating AST nodes, etc and seems heavier.

While trying byebug on TruffleRuby, I found this is the first issue. This change seems to fix it.

The next issue is supporting the TracePoint `:call` event in TruffleRuby: https://github.com/oracle/truffleruby/issues/1672.