### PR TITLE
Drop ruby 2.4 support

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [2.4.9, 2.5.7, 2.6.5, 2.7.0]
+        version: [2.5.7, 2.6.5, 2.7.0]
         line_editor: [libedit, readline]
         compiler: [clang, gcc]
 
@@ -31,13 +31,13 @@ jobs:
 
       - name: Save coverage
         run: mv coverage/.resultset.json coverage/${{ matrix.version }}-${{ matrix.line_editor }}-${{ matrix.compiler }}.json
-        if: startsWith(matrix.version, '2.4') || startsWith(matrix.version, '2.5')
+        if: startsWith(matrix.version, '2.5')
 
       - uses: actions/upload-artifact@v1
         with:
           name: coverage-${{ matrix.version }}-${{ matrix.line_editor }}-${{ matrix.compiler }}
           path: coverage/${{ matrix.version }}-${{ matrix.line_editor }}-${{ matrix.compiler }}.json
-        if: startsWith(matrix.version, '2.4') || startsWith(matrix.version, '2.5')
+        if: startsWith(matrix.version, '2.5')
 
     timeout-minutes: 15
 
@@ -50,26 +50,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/download-artifact@v1
-        with:
-          name: coverage-2.4.9-libedit-clang
-          path: coverage
-
-      - uses: actions/download-artifact@v1
-        with:
-          name: coverage-2.4.9-libedit-gcc
-          path: coverage
-
-      - uses: actions/download-artifact@v1
-        with:
-          name: coverage-2.4.9-readline-clang
-          path: coverage
-
-      - uses: actions/download-artifact@v1
-        with:
-          name: coverage-2.4.9-readline-gcc
-          path: coverage
 
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [2.4.9, 2.5.7, 2.6.5, 2.7.0, head]
+        version: [2.5.7, 2.6.5, 2.7.0, head]
 
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
 
   DisabledByDefault: true
 
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Layout/AccessModifierIndentation:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+* Support for MRI 2.4. Byebug no longer installs on this platform.
+
 ## [11.1.3] - 2020-04-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ more][Tidelift for enterprise].
 
 ## Requirements
 
-* _Required_: MRI 2.4.0 or higher.
+* _Required_: MRI 2.5.0 or higher.
 * _Recommended_: MRI 2.6.4 or higher (MRI 2.6.0 to 2.6.3 contain a regression
   causing unbalanced call/return events in some cases, breaking the `next` command).
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,11 +16,9 @@ task "release:rubygem_push" => "chandler:push"
 if Gem.win_platform?
   desc "Activates DevKit"
   task :devkit do
-    begin
-      require "devkit"
-    rescue LoadError
-      abort "Failed to load DevKit required for compilation"
-    end
+    require "devkit"
+  rescue LoadError
+    abort "Failed to load DevKit required for compilation"
   end
 
   task compile: :devkit

--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     can build on. It provides breakpoint handling and bindings for stack frames
     among other things and it comes with an easy to use command line interface."
 
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.files = Dir["lib/**/*.rb", "lib/**/*.yml", "ext/**/*.[ch]", "LICENSE"]
   s.bindir = "exe"

--- a/docker/manager.rb
+++ b/docker/manager.rb
@@ -10,7 +10,6 @@ module Docker
   #
   class Manager
     VERSIONS = %w[
-      2.4.9
       2.5.7
       2.6.5
       2.7.0

--- a/lib/byebug/helpers/parse.rb
+++ b/lib/byebug/helpers/parse.rb
@@ -36,12 +36,10 @@ module Byebug
         return true unless code
 
         without_stderr do
-          begin
-            RubyVM::InstructionSequence.compile(code)
-            true
-          rescue SyntaxError
-            false
-          end
+          RubyVM::InstructionSequence.compile(code)
+          true
+        rescue SyntaxError
+          false
         end
       end
 

--- a/test/commands/break_test.rb
+++ b/test/commands/break_test.rb
@@ -43,61 +43,37 @@ module Byebug
     def test_break_with_instance_method_stops_at_correct_place
       enter "break #{example_class}#b", "cont"
 
-      if RUBY_VERSION >= "2.5.0"
-        debug_code(program) { assert_location example_path, 13 }
-      else
-        debug_code(program) { assert_location example_path, 12 }
-      end
+      debug_code(program) { assert_location example_path, 13 }
     end
 
     def test_break_with_namespaced_instance_method_stops_at_correct_place
       enter "break Byebug::#{example_class}#b", "cont"
 
-      if RUBY_VERSION >= "2.5.0"
-        debug_code(program) { assert_location example_path, 13 }
-      else
-        debug_code(program) { assert_location example_path, 12 }
-      end
+      debug_code(program) { assert_location example_path, 13 }
     end
 
     def test_break_with_class_method_stops_at_correct_place
       enter "break #{example_class}.a", "cont"
 
-      if RUBY_VERSION >= "2.5.0"
-        debug_code(program) { assert_location example_path, 7 }
-      else
-        debug_code(program) { assert_location example_path, 6 }
-      end
+      debug_code(program) { assert_location example_path, 7 }
     end
 
     def test_break_with_namespaced_class_method_stops_at_correct_place
       enter "break Byebug::#{example_class}.a", "cont"
 
-      if RUBY_VERSION >= "2.5.0"
-        debug_code(program) { assert_location example_path, 7 }
-      else
-        debug_code(program) { assert_location example_path, 6 }
-      end
+      debug_code(program) { assert_location example_path, 7 }
     end
 
     def test_break_with_module_method_stops_at_correct_place
       enter "break #{example_module}.c", "cont"
 
-      if RUBY_VERSION >= "2.5.0"
-        debug_code(program) { assert_location(example_path, 19) }
-      else
-        debug_code(program) { assert_location(example_path, 18) }
-      end
+      debug_code(program) { assert_location(example_path, 19) }
     end
 
     def test_break_with_namespaced_module_method_stops_at_correct_place
       enter "break Byebug::#{example_module}.c", "cont"
 
-      if RUBY_VERSION >= "2.5.0"
-        debug_code(program) { assert_location example_path, 19 }
-      else
-        debug_code(program) { assert_location example_path, 18 }
-      end
+      debug_code(program) { assert_location example_path, 19 }
     end
 
     def test_break_with_a_method_does_not_stop_at_blocks_in_the_method

--- a/test/commands/debug_test.rb
+++ b/test/commands/debug_test.rb
@@ -35,11 +35,7 @@ module Byebug
     def test_subdebugger_stops_at_correct_point_when_invoked_from_breakpoint
       enter "break #{example_class}.a", "debug #{example_class}.a"
 
-      if RUBY_VERSION >= "2.5.0"
-        debug_code(program) { assert_equal 7, frame.line }
-      else
-        debug_code(program) { assert_equal 6, frame.line }
-      end
+      debug_code(program) { assert_equal 7, frame.line }
     end
 
     def test_subdebugger_goes_back_to_previous_debugger_after_continue


### PR DESCRIPTION
Since it has reached its End of Life period: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/.