### PR TITLE
Skip warning about `$SAFE` global variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#741](https://github.com/deivid-rodriguez/byebug/pull/741): Small consistency issues in help messages.
 * [#743](https://github.com/deivid-rodriguez/byebug/pull/743): `untracevar` command crashing when giving a non existent global variable.
 * [#744](https://github.com/deivid-rodriguez/byebug/pull/744): Another punctuation tweak in `enable breakpoints` help message.
+* [#736](https://github.com/deivid-rodriguez/byebug/pull/736): Skip warning about `$SAFE` global variable on ruby 2.7 when listing global variables.
 
 ### Removed
 

--- a/lib/byebug/helpers/eval.rb
+++ b/lib/byebug/helpers/eval.rb
@@ -33,7 +33,7 @@ module Byebug
 
       #
       # Evaluates a string containing Ruby code in a specific binding,
-      # returning nil in an error happens.
+      # returning nil if an error happens.
       #
       def silent_eval(str, binding = frame._binding)
         safe_eval(str, binding) { |_e| nil }


### PR DESCRIPTION
When accessing `$SAFE`, ruby 2.7 will print a warning about it becoming a regular global variable. While this might help users relying on the previous special functionality, I don't think it's useful in the context of listing global variables inside a debugger.