### PR TITLE
Unclobber YARD docs generation

### DIFF
--- a/ext/byebug/byebug.c
+++ b/ext/byebug/byebug.c
@@ -854,7 +854,7 @@ Add_catchpoint(VALUE self, VALUE value)
 }
 
 /*
- *   Document-class: Byebug
+ *   Document-module: Byebug
  *
  *   == Summary
  *


### PR DESCRIPTION
Replacing `Document-class: Byebug` with `Document-module: Byebug` in `ext/byebug/byebug.c` fixes `yard doc`. Without this, it appears that YARD clobbers everything except what's in the C files. At the time of writing, https://rubydoc.info/gems/byebug contains only the following:

* Byebug (module)
  * DebugThread < Thread
  * ThreadsTable < Object
* Context < Object
* Exception
* Kernel
* ThreadsTable < Object

This is missing almost all the Ruby classes. This change un-confuses YARD, resulting in documentation for the Ruby code.