### PR TITLE
Allow Breakpoint#hit_condition=(nil)

### DIFF
--- a/ext/byebug/breakpoint.c
+++ b/ext/byebug/breakpoint.c
@@ -128,6 +128,13 @@ brkpt_set_hit_condition(VALUE self, VALUE value)
   ID id_value;
 
   Data_Get_Struct(self, breakpoint_t, breakpoint);
+
+  if (NIL_P(value))
+  {
+    breakpoint->hit_condition = HIT_COND_NONE;
+    return value;
+  }
+
   id_value = rb_to_id(value);
 
   if (rb_intern("greater_or_equal") == id_value || rb_intern("ge") == id_value)


### PR DESCRIPTION
Closes #739.

This MR modifies `brkpt_set_hit_condition` in `ext/byebug/breakpoint.c` to allow clearing a breakpoint's hit condition by setting it to nil. The documentation on the function indicates this should be possible, but passing nil will raise an exception, and no code path in the function will set the condition to `HIT_COND_NONE`.