### PR TITLE
Don't fail fast in CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-18.04
 
     strategy:
+      fail-fast: false
+
       matrix:
         line_editor: [libedit, readline]
         compiler: [clang, gcc]
@@ -44,6 +46,8 @@ jobs:
     runs-on: ubuntu-18.04
 
     strategy:
+      fail-fast: false
+
       matrix:
         line_editor: [libedit, readline]
         compiler: [clang, gcc]

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-18.04
 
     strategy:
+      fail-fast: false
+
       matrix:
         version: [2.5.7, 2.6.5, 2.7.0]
         line_editor: [libedit, readline]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: windows-2019
 
     strategy:
+      fail-fast: false
+
       matrix:
         version: [2.5.7, 2.6.5, 2.7.0, head]
 


### PR DESCRIPTION
Our build is fast, so we don't need it.