### PR TITLE
Add `timeout-minutes` to Windows workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,3 +44,5 @@ jobs:
       - name: Run tests
         run: ruby bin/rake
         continue-on-error: ${{ matrix.version == 'head' }}
+
+    timeout-minutes: 15


### PR DESCRIPTION
Windows sometimes hangs so this is most useful there.