### PR TITLE
Add ignore_empty_commands setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Command     | Aliases         | Subcommands
 `quit!`     | `q!`            |
 `restart`   |                 |
 `save`      | `sa`            |
-`set`       |                 | `autoirb` `autolist` `autopry` `autosave` `basename` `callstyle` `fullpath` `histfile` `histsize` `linetrace` `listsize` `post_mortem` `savefile` `stack_on_error` `width`
-`show`      |                 | `autoirb` `autolist` `autopry` `autosave` `basename` `callstyle` `fullpath` `histfile` `histsize` `linetrace` `listsize` `post_mortem` `savefile` `stack_on_error` `width`
+`set`       |                 | `autoirb` `autolist` `autopry` `autosave` `basename` `callstyle` `fullpath` `ignore_empty_commands` `histfile` `histsize` `linetrace` `listsize` `post_mortem` `savefile` `stack_on_error` `width`
+`show`      |                 | `autoirb` `autolist` `autopry` `autosave` `basename` `callstyle` `fullpath` `ignore_empty_commands` `histfile` `histsize` `linetrace` `listsize` `post_mortem` `savefile` `stack_on_error` `width`
 `skip`      | `sk`            |
 `source`    | `so`            |
 `step`      | `s`             |

--- a/lib/byebug/interface.rb
+++ b/lib/byebug/interface.rb
@@ -71,6 +71,8 @@ module Byebug
       line = readline(prompt)
       return unless line
 
+      return '' if line.empty? && Setting[:ignore_empty_commands]
+
       last_if_empty(line)
     end
 

--- a/lib/byebug/settings/ignore_empty_commands.rb
+++ b/lib/byebug/settings/ignore_empty_commands.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../setting"
+
+module Byebug
+  #
+  # Setting to control what Byebug does when the user enters an empty
+  # command (presses enter without a command).
+  #
+  class IgnoreEmptyCommandsSetting < Setting
+    DEFAULT = false
+
+    def banner
+      "Enable/disable running the last command upon empty commands"
+    end
+  end
+end

--- a/test/commands/set_test.rb
+++ b/test/commands/set_test.rb
@@ -20,7 +20,7 @@ module Byebug
     end
 
     settings =
-      %i[autolist autosave basename fullpath post_mortem stack_on_error]
+      %i[autolist autosave basename fullpath ignore_empty_commands post_mortem stack_on_error]
 
     settings.each do |set|
       ["on", "1", "true", ""].each do |key|

--- a/test/processors/command_processor_test.rb
+++ b/test/processors/command_processor_test.rb
@@ -32,6 +32,14 @@ module Byebug
       debug_code(program) { assert_equal 6, frame.line }
     end
 
+    def test_empty_command_does_not_repeat_last_command_when_ignoring_empty_commands
+      with_setting :ignore_empty_commands, true do
+        enter "n", ""
+
+        debug_code(program) { assert_equal 5, frame.line }
+      end
+    end
+
     def test_multiple_commands_are_executed_sequentially
       enter "n ; n"
 


### PR DESCRIPTION
Add `ignore_empty_commands` boolean setting. It defaults to false, which causes an empty command to repeat the last command (the current behavior). If true, an empty command is a no-op.

My implementation differs from what I suggested in issue #700 because it seemed more self-documenting as a boolean setting. Also if I used an enum setting instead, I doubt a third value would ever be added, so the flexibility of an enum would provide no benefit. But I am happy to switch it back to the enum setting that I initially proposed if that is what you prefer!

Fixes #700

# Demo

## When the setting is false

```
$ cat ~/.byebugrc
set histfile /home/gabrielx/byebug.history
#set ignore_empty_commands true
$
$ bundle exec ./test.rb

[3, 12] in /home/gabrielx/projects/byebug/test.rb
    3:
    4: require 'byebug'
    5:
    6: debugger
    7:
=>  8: sleep 2.1
    9: debugger
   10:
   11: sleep 2.2
   12: debugger
(byebug) c

[3, 12] in /home/gabrielx/projects/byebug/test.rb
    3:
    4: require 'byebug'
    5:
    6: debugger
    7:
    8: sleep 2.1
    9: debugger
   10:
=> 11: sleep 2.2
   12: debugger
(byebug)

[21, 30] in /home/gabrielx/.rvm/gems/ruby-2.5.3/gems/bundler-2.2.0.rc.2/lib/bundler/cli.rb
   21:     }.freeze
   22:
   23:     def self.start(*)
   24:       super
   25:     ensure
=> 26:       Bundler::SharedHelpers.print_major_deprecations!
   27:     end
   28:
   29:     def self.dispatch(*)
   30:       super do |i|
(byebug)
$
```

### When the setting is true
```
$ cat ~/.byebugrc
set histfile /home/gabrielx/byebug.history
set ignore_empty_commands true
$
$ bundle exec ./test.rb

[3, 12] in /home/gabrielx/projects/byebug/test.rb
    3:
    4: require 'byebug'
    5:
    6: debugger
    7:
=>  8: sleep 2.1
    9: debugger
   10:
   11: sleep 2.2
   12: debugger
(byebug) c

[3, 12] in /home/gabrielx/projects/byebug/test.rb
    3:
    4: require 'byebug'
    5:
    6: debugger
    7:
    8: sleep 2.1
    9: debugger
   10:
=> 11: sleep 2.2
   12: debugger
(byebug)
(byebug)
(byebug) c

[21, 30] in /home/gabrielx/.rvm/gems/ruby-2.5.3/gems/bundler-2.2.0.rc.2/lib/bundler/cli.rb
   21:     }.freeze
   22:
   23:     def self.start(*)
   24:       super
   25:     ensure
=> 26:       Bundler::SharedHelpers.print_major_deprecations!
   27:     end
   28:
   29:     def self.dispatch(*)
   30:       super do |i|
(byebug)
(byebug)
(byebug) c
$
```