### PR TITLE
Document the behavior change of wait_connection

### DIFF
--- a/lib/byebug/breakpoint.rb
+++ b/lib/byebug/breakpoint.rb
@@ -69,7 +69,7 @@ module Byebug
 
     #
     # Returns true if a breakpoint could be set in line number +lineno+ in file
-    # name +filename.
+    # name +filename+.
     #
     def self.potential_line?(filename, lineno)
       potential_lines(filename).member?(lineno)

--- a/lib/byebug/remote.rb
+++ b/lib/byebug/remote.rb
@@ -36,6 +36,9 @@ module Byebug
     #
     # Starts the remote server main thread
     #
+    # If wait_connection is set to true, the call waits for the first client
+    # connection.
+    #
     def start_server(host = nil, port = PORT)
       start_control(host, port.zero? ? 0 : port + 1)
 

--- a/lib/byebug/remote/server.rb
+++ b/lib/byebug/remote/server.rb
@@ -19,6 +19,9 @@ module Byebug
       #
       # Start the remote debugging server
       #
+      # If wait_connection is set to true, the call waits for the first client
+      # connection.
+      #
       def start(host, port)
         return if @thread
 


### PR DESCRIPTION
The [description of wait_connection](https://github.com/deivid-rodriguez/byebug/blob/ddad523427d4ccb5c94aa4858b64b4bbf3d0399c/lib/byebug/remote.rb#L16) doesn't explain the behavior change of `start_server` exactly, so I thought it's best to describe it there.