### PR TITLE
Load IRB lazily

### DIFF
--- a/lib/byebug/commands/irb.rb
+++ b/lib/byebug/commands/irb.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../command"
-require "irb"
 require "English"
 
 module Byebug
@@ -29,6 +28,8 @@ module Byebug
 
     def execute
       return errmsg(pr("base.errors.only_local")) unless processor.interface.instance_of?(LocalInterface)
+
+      require "irb"
 
       # @todo IRB tries to parse $ARGV so we must clear it (see #197). Add a
       #   test case for it so we can remove this comment.


### PR DESCRIPTION
This PR makes loading IRB lazy. It improves startup time.


# Problem

Byebug always loads IRB, but IRB is necessary only for `irb` command. It makes startup time slower unnecessarily for non-IRB users.




# Solution

Let's load IRB lazily.


# Benchmark

About 55ms (50%) faster.

## before

```bash
$ RUBYLIB=lib ruby -rbenchmark -e 'p Benchmark.realtime{require "byebug/core"};'
0.11415267689153552
```


## after

```bash
$ RUBYLIB=lib ruby -rbenchmark -e 'p Benchmark.realtime{require "byebug/core"};'
0.059115791926160455
```