### PR TITLE
Switch foreground process group

### DIFF
--- a/ext/byebug/byebug.c
+++ b/ext/byebug/byebug.c
@@ -708,6 +708,12 @@ Start(VALUE self)
   return Qtrue;
 }
 
+static VALUE
+Foreground_process_group_id(int tty_fd, VALUE self)
+{
+  return tcgetpgrp(tty_fd);
+}
+
 /*
  *  call-seq:
  *    Byebug.debug_load(file, stop = false) -> nil

--- a/ext/byebug/byebug.c
+++ b/ext/byebug/byebug.c
@@ -709,9 +709,18 @@ Start(VALUE self)
 }
 
 static VALUE
-Foreground_process_group_id(int tty_fd, VALUE self)
+Foreground_process_group_id(VALUE self, VALUE tty_fd)
 {
-  return tcgetpgrp(tty_fd);
+  Check_Type(tty_fd, T_FIXNUM);
+  return INT2NUM(tcgetpgrp(NUM2INT(tty_fd)));
+}
+
+static VALUE
+Set_foreground_process_group_id(VALUE self, VALUE tty_fd, VALUE pgrp)
+{
+  Check_Type(tty_fd, T_FIXNUM);
+  Check_Type(pgrp, T_FIXNUM);
+  return INT2NUM(tcsetpgrp(NUM2INT(tty_fd), NUM2INT(pgrp)));
 }
 
 /*
@@ -890,6 +899,8 @@ Init_byebug()
   rb_define_module_function(mByebug, "tracing=", Set_tracing, 1);
   rb_define_module_function(mByebug, "verbose?", Verbose, 0);
   rb_define_module_function(mByebug, "verbose=", Set_verbose, 1);
+  rb_define_module_function(mByebug, "foreground_process_group_id", Foreground_process_group_id, 1);
+  rb_define_module_function(mByebug, "set_foreground_process_group_id", Set_foreground_process_group_id, 2);
 
   Init_threads_table(mByebug);
   Init_byebug_context(mByebug);

--- a/lib/byebug/attacher.rb
+++ b/lib/byebug/attacher.rb
@@ -13,11 +13,10 @@ module Byebug
 
       start
       run_init_script
+      ensure_foreground
     end
 
-    ensure_foreground do
-      current_context.step_out(3, true)
-    end
+    current_context.step_out(3, true)
   end
 
   def self.spawn(host = "localhost", port = nil)

--- a/lib/byebug/attacher.rb
+++ b/lib/byebug/attacher.rb
@@ -15,7 +15,9 @@ module Byebug
       run_init_script
     end
 
-    current_context.step_out(3, true)
+    ensure_foreground do
+      current_context.step_out(3, true)
+    end
   end
 
   def self.spawn(host = "localhost", port = nil)

--- a/lib/byebug/core.rb
+++ b/lib/byebug/core.rb
@@ -69,6 +69,30 @@ module Byebug
     end
   end
 
+  def ensure_foreground
+    fg_group_id = foreground_process_group_id
+    group_id = Process.getpgrp
+
+    if group_id == fg_group_id
+      puts "========== Already in foreground"
+      yield
+    else
+      puts "========== In background"
+      yield
+      # begin
+      #   prev_ttou_handler = Signal.trap('SIGTTOU', 'IGNORE')
+      #   tty = File.open('/dev/tty', 'r')
+      #   set_foreground_process_group_id(tty.fileno, group_id)
+
+      #   yield
+      # ensure
+      #   set_foreground_process_group_id(tty.fileno, fg_group_id)
+      #   tty.close
+      #   Signal.trap('SIGTTOU', prev_ttou_handler)
+      # end
+    end
+  end
+
   #
   # Saves information about the unhandled exception and gives a byebug
   # prompt back to the user before program termination.


### PR DESCRIPTION
Resolves https://github.com/deivid-rodriguez/byebug/issues/830

This is a first stab at fixing https://github.com/deivid-rodriguez/byebug/issues/830 by switching the foreground process group to the one byebug is running in, if it detects it is running in a background process group. It's not fully ready, but I'd like feedback on the general approach before polishing it further.

TODO:
- [ ] Switch back to the original foreground process group after debugging?
- [ ] Check cross-platform operation
- [ ] Evaluate for unintended side-effects
- [ ] Documentation
- [ ] Tests?