### PR TITLE
Fix "undefining the allocator of T_DATA" error seen in Ruby 3.2   

### DIFF
--- a/ext/byebug/context.c
+++ b/ext/byebug/context.c
@@ -658,6 +658,7 @@ void
 Init_byebug_context(VALUE mByebug)
 {
   cContext = rb_define_class_under(mByebug, "Context", rb_cObject);
+  rb_undef_alloc_func(cContext);
 
   rb_define_method(cContext, "backtrace", Context_backtrace, 0);
   rb_define_method(cContext, "dead?", Context_dead, 0);

--- a/ext/byebug/threads.c
+++ b/ext/byebug/threads.c
@@ -224,6 +224,7 @@ void
 Init_threads_table(VALUE mByebug)
 {
   cThreadsTable = rb_define_class_under(mByebug, "ThreadsTable", rb_cObject);
+  rb_undef_alloc_func(cThreadsTable);
 
   rb_define_module_function(mByebug, "unlock", Unlock, 0);
   rb_define_module_function(mByebug, "lock", Lock, 0);


### PR DESCRIPTION
## Description

A `undefining the allocator of T_DATA` warning was added for c extensions to ensure they adhere to the requirements explained in "doc/extension.rdoc".
Context and implementation can be found here: https://bugs.ruby-lang.org/issues/18007

This PR ensures that users of byebug don't have to deal with this warning.

## Implementation

The objects created by `rb_define_class_under` need to have `rb_undef_alloc_func` called on them. Here is an example from another gem: https://github.com/swig/swig/pull/2527