### PR TITLE
Add 'fiddle' gem as a runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     byebug (11.1.3)
+      fiddle (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -15,6 +16,7 @@ GEM
     docile (1.3.4)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
+    fiddle (1.1.2)
     method_source (1.0.0)
     minitest (5.14.4)
     multipart-post (2.1.1)

--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -25,5 +25,7 @@ Gem::Specification.new do |s|
   s.extensions = ["ext/byebug/extconf.rb"]
   s.require_path = "lib"
 
+  s.add_dependency "fiddle", "~> 1.0"
+
   s.add_development_dependency "bundler", "~> 2.0"
 end


### PR DESCRIPTION
Fixes deivid-rodriguez/byebug#851

The following warning is printed to stderr when using byebug on Ruby 3.3.5:

> /home/david/.rbenv/versions/3.3.5/lib/ruby/3.3.0/reline.rb:9: warning: fiddle was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
>
> You can add fiddle to your Gemfile or gemspec to silence this warning.

This change aims to cause that warning no longer to appear, by implementing one of the suggestions in the warning message, i.e. by adding the `fiddle` gem to byebug's gemspec as a runtime dependency.