### PR TITLE
Add more options to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,5 @@
 ---
 
+github: deivid-rodriguez
+liberapay: byebug
 tidelift: "rubygems/byebug"


### PR DESCRIPTION
Included your github sponsors and liberapay accounts. 

Which would you prefer adding to `funding_uri` in the gemspec?