### PR TITLE
Add reline as an explicit dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     byebug (12.0.0)
+      reline (>= 0.6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -20,6 +21,7 @@ GEM
       net-http (>= 0.5.0)
     faraday-retry (2.3.2)
       faraday (~> 2.0)
+    io-console (0.8.0)
     json (2.15.0)
     logger (1.7.0)
     method_source (1.0.0)
@@ -37,6 +39,8 @@ GEM
     rake (13.3.0)
     rake-compiler (1.3.0)
       rake
+    reline (0.6.0)
+      io-console (~> 0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)

--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -25,5 +25,7 @@ Gem::Specification.new do |s|
   s.extensions = ["ext/byebug/extconf.rb"]
   s.require_path = "lib"
 
+  s.add_dependency "reline", ">= 0.6.0"
+
   s.add_development_dependency "bundler", "~> 2.0"
 end


### PR DESCRIPTION
Fixes warnings in Ruby 3.4 like

> /path/to/ruby/3.4.6/lib/ruby/3.4.0/readline.rb:4: warning: reline was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
> You can add reline to your Gemfile or gemspec to silence this warning