### PR TITLE
No need to go through readline wrapper

### DIFF
--- a/lib/byebug/history.rb
+++ b/lib/byebug/history.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "readline"
-rescue LoadError
-  warn <<-MESSAGE
-    Sorry, you can't use byebug without Readline. To solve this, you need to
-    rebuild Ruby with Readline support. If using Ubuntu, try `sudo apt-get
-    install libreadline-dev` and then reinstall your Ruby.
-  MESSAGE
-
-  raise
-end
+require "reline"
 
 module Byebug
   #
@@ -27,7 +17,7 @@ module Byebug
     # Array holding the list of commands in history
     #
     def buffer
-      Readline::HISTORY.to_a
+      Reline::HISTORY.to_a
     end
 
     #
@@ -60,21 +50,21 @@ module Byebug
     end
 
     #
-    # Adds a new command to Readline's history.
+    # Adds a new command to Reline's history.
     #
     def push(cmd)
       return if ignore?(cmd)
 
       @size += 1
-      Readline::HISTORY.push(cmd)
+      Reline::HISTORY.push(cmd)
     end
 
     #
-    # Removes a command from Readline's history.
+    # Removes a command from Reline's history.
     #
     def pop
       @size -= 1
-      Readline::HISTORY.pop
+      Reline::HISTORY.pop
     end
 
     #
@@ -122,9 +112,9 @@ module Byebug
     #
     def ignore?(buf)
       return true if /^\s*$/.match?(buf)
-      return false if Readline::HISTORY.empty?
+      return false if Reline::HISTORY.empty?
 
-      buffer[Readline::HISTORY.length - 1] == buf
+      buffer[Reline::HISTORY.length - 1] == buf
     end
   end
 end

--- a/lib/byebug/interfaces/local_interface.rb
+++ b/lib/byebug/interfaces/local_interface.rb
@@ -15,13 +15,13 @@ module Byebug
     end
 
     #
-    # Reads a single line of input using Readline. If Ctrl-D is pressed, it
+    # Reads a single line of input using Reline. If Ctrl-D is pressed, it
     # returns "continue", meaning that program's execution will go on.
     #
     # @param prompt Prompt to be displayed.
     #
     def readline(prompt)
-      with_repl_like_sigint { without_readline_completion { Readline.readline(prompt) || EOF_ALIAS } }
+      with_repl_like_sigint { without_reline_completion { Reline.readline(prompt) || EOF_ALIAS } }
     end
 
     #
@@ -42,21 +42,21 @@ module Byebug
     end
 
     #
-    # Disable any Readline completion procs.
+    # Disable any Reline completion procs.
     #
     # Other gems, for example, IRB could've installed completion procs that are
     # dependent on them being loaded. Disable those while byebug is the REPL
-    # making use of Readline.
+    # making use of Reline.
     #
-    def without_readline_completion
-      orig_completion = Readline.completion_proc
+    def without_reline_completion
+      orig_completion = Reline.completion_proc
       return yield unless orig_completion
 
       begin
-        Readline.completion_proc = ->(_) { nil }
+        Reline.completion_proc = ->(_) { nil }
         yield
       ensure
-        Readline.completion_proc = orig_completion
+        Reline.completion_proc = orig_completion
       end
     end
   end

--- a/test/interfaces/local_interface_test.rb
+++ b/test/interfaces/local_interface_test.rb
@@ -9,8 +9,8 @@ module Byebug
   #
   class LocalInterfaceTest < TestCase
     def test_continues_by_control_d
-      # `Readline.readline` returns nil for Control-D
-      Readline.stub(:readline, nil) do
+      # `Reline.readline` returns nil for Control-D
+      Reline.stub(:readline, nil) do
         interface = LocalInterface.new
         assert_equal "continue", interface.readline("(byebug)")
       end

--- a/test/processors/script_processor_test.rb
+++ b/test/processors/script_processor_test.rb
@@ -10,11 +10,11 @@ module Byebug
     include TestUtils
 
     def test_script_processor_clears_history
-      previous_history = Readline::HISTORY.to_a
+      previous_history = Reline::HISTORY.to_a
 
       process_rc_file("set callstyle long")
 
-      assert_equal previous_history, Readline::HISTORY.to_a
+      assert_equal previous_history, Reline::HISTORY.to_a
     end
 
     def test_script_processor_closes_files


### PR DESCRIPTION
Right now byebug may end up using readline instead of reline if the readline-ext gem is installed.

Let's use reline exclusively.