### PR TITLE
Prefer faraday to net/http for fetching ruby release info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development do
   gem "rake", "~> 13.0"
   gem "rake-compiler", "~> 1.0"
   gem "yard", "0.9.37"
+  gem "faraday", "~> 2.14"
   gem "faraday-retry", "~> 2.2"
   gem "irb", "~> 1.15"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ DEPENDENCIES
   bundler (~> 2.0)
   byebug!
   chandler (= 0.9.0)
+  faraday (~> 2.14)
   faraday-retry (~> 2.2)
   irb (~> 1.15)
   minitest (~> 5.25)

--- a/docker/manager.rb
+++ b/docker/manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "net/http"
+require "faraday"
 require "yaml"
 require "open3"
 
@@ -93,7 +93,7 @@ module Docker
 
       def release_info
         @release_info ||= YAML.safe_load(
-          Net::HTTP.get(URI.parse(releases_url)),
+          Faraday.get(releases_url).body,
           permitted_classes: [Date]
         )
       end


### PR DESCRIPTION
net-http is having issues with the latest openssl version, unless the openssl gem is updated to 3.3.1. However, net-http does not declare openssl as a dependency, so we need to artificially add it to the Gemfile in order to use the latest version.

faraday seems to just work though, so let's use that.