### PR TITLE
Use cross-runtime check for valid syntax

### DIFF
--- a/lib/byebug/helpers/parse.rb
+++ b/lib/byebug/helpers/parse.rb
@@ -45,10 +45,12 @@ module Byebug
             false
           end
         else
-          require "ripper" unless defined?(Ripper)
-          without_stderr do
-            !Ripper.sexp(code).nil?
+          code = code.b
+          code.sub!(/\A(?:\xef\xbb\xbf)?(\s*\#.*$)*(\n)?/n) do
+            "#{::Regexp.last_match(0)}#{"\n" if ::Regexp.last_match(1) && !::Regexp.last_match(2)}BEGIN{throw tag, :ok}\n"
           end
+          code = code.force_encoding(Encoding::UTF_8)
+          catch { |tag| eval(code, binding, __FILE__, __LINE__ - 1) } == :ok
         end
       end
 


### PR DESCRIPTION
Ripper may or may not go aay at some point, and we can use this code to work on all ruby runtimes without having to worry about another require.

This code itself comes directly from CRuby's test suite:

https://github.com/ruby/ruby/blob/9e89e5f3c39568add64eb4e5990575b9508089ac/tool/lib/core_assertions.rb#L157-L164