### PR TITLE
Fix next skipping chained calls in class_eval-defined methods

### DIFF
--- a/ext/byebug/byebug.c
+++ b/ext/byebug/byebug.c
@@ -275,9 +275,9 @@ line_event(VALUE trace_point, void *data)
   if (!CTX_FL_TEST(dc, CTX_FL_IGNORE_STEPS))
     dc->steps = dc->steps <= 0 ? -1 : dc->steps - 1;
 
-  if (dc->calced_stack_size <= dc->dest_frame)
+  if (dc->ruby_stack_size <= dc->dest_frame)
   {
-    dc->dest_frame = dc->calced_stack_size;
+    dc->dest_frame = dc->ruby_stack_size;
     CTX_FL_UNSET(dc, CTX_FL_IGNORE_STEPS);
 
     dc->lines = dc->lines <= 0 ? -1 : dc->lines - 1;
@@ -309,6 +309,7 @@ call_event(VALUE trace_point, void *data)
   if (dc->calced_stack_size <= dc->dest_frame)
     CTX_FL_UNSET(dc, CTX_FL_IGNORE_STEPS);
 
+  dc->ruby_stack_size++;
   CALL_EVENT_SETUP;
 
   msym = rb_tracearg_method_id(trace_arg);
@@ -339,6 +340,8 @@ return_event(VALUE trace_point, void *data)
 
   EVENT_SETUP;
 
+  if (rb_tracearg_event_flag(trace_arg) & RUBY_EVENT_RETURN)
+    dc->ruby_stack_size--;
   RETURN_EVENT_SETUP;
 
   if ((dc->steps_out == 0) && (CTX_FL_TEST(dc, CTX_FL_STOP_ON_RET)))

--- a/ext/byebug/byebug.h
+++ b/ext/byebug/byebug.h
@@ -40,7 +40,8 @@ typedef enum
 
 typedef struct
 {
-  int calced_stack_size;
+  int calced_stack_size; /* all frames: Ruby + C + blocks          */
+  int ruby_stack_size;   /* Ruby-only frames (CALL/RETURN events)  */
   int flags;
   ctx_stop_reason stop_reason;
 

--- a/ext/byebug/context.c
+++ b/ext/byebug/context.c
@@ -87,6 +87,7 @@ byebug_context_create(VALUE thread)
 
   rb_debug_inspector_open(context_backtrace_set, (void *)context);
   context->calced_stack_size = dc_stack_size(context) + 1;
+  context->ruby_stack_size = context->calced_stack_size;
 
   if (rb_obj_class(thread) == cDebugThread)
     CTX_FL_SET(context, CTX_FL_IGNORE);
@@ -102,6 +103,7 @@ context_dup(debug_context_t *context)
 
   memcpy(new_context, context, sizeof(debug_context_t));
   byebug_reset_stepping_stop_points(new_context);
+  new_context->ruby_stack_size = context->ruby_stack_size;
   new_context->backtrace = context->backtrace;
   CTX_FL_SET(new_context, CTX_FL_DEAD);
 
@@ -506,7 +508,7 @@ Context_step_over(int argc, VALUE *argv, VALUE self)
              frame, context->calced_stack_size);
 
   context->lines = FIX2INT(lines);
-  context->dest_frame = context->calced_stack_size - frame;
+  context->dest_frame = context->ruby_stack_size - frame;
 
   return Qnil;
 }

--- a/test/commands/next_test.rb
+++ b/test/commands/next_test.rb
@@ -287,4 +287,37 @@ module Byebug
       debug_code(program) { assert_equal 5, frame.line }
     end
   end
+
+  #
+  # Test for [#877](https://github.com/deivid-rodriguez/byebug/issues/877)
+  #
+  class NextWithMethodCallChainTest < TestCase
+    def program
+      strip_line_numbers <<-RUBY
+         1:  module Byebug
+         2:    class #{example_class}
+         3:      def self.get_obj
+         4:        self
+         5:      end
+         6:
+         7:      def self.target
+         8:        true
+         9:      end
+        10:    end
+        11:
+        12:    byebug
+        13:
+        14:    #{example_class}.get_obj.method(:target).call
+        15:
+        16:    "done"
+        17:  end
+      RUBY
+    end
+
+    def test_next_does_not_skip_chained_call_through_c_method
+      enter "step", "next"
+
+      debug_code(program) { assert_location example_path, 8 }
+    end
+  end
 end


### PR DESCRIPTION
The `next` command incorrectly skips remaining chained method calls when
inside a method defined via `class_eval` with explicit `__FILE__` and
`__LINE__` arguments (as Capybara's DSL does).

Root cause: `step_over` and `line_event` use `calced_stack_size` to
decide whether execution has returned to the target frame. This counter
tracks all frames including C calls and blocks. When a chain like
`obj.method(:foo).call(arg)` is executed, the intermediate C-level
`Method#call` inflates `calced_stack_size`, making byebug think it
hasn't returned to the original frame yet. On return, it overshoots past
the entire line.

Fix: introduce `ruby_stack_size`, a counter that only tracks Ruby method
frames (CALL/RETURN events, excluding B_CALL/B_RETURN and C events). Use
this for the `dest_frame` comparison in `step_over` and `line_event`,
so intermediate C frames don't affect the frame depth calculation.

Fixes https://github.com/deivid-rodriguez/byebug/issues/877

---
Original text

Reproduces the bug reported in issue #877: when stepping inside a method defined via class_eval with explicit __FILE__ and __LINE__ (as Capybara's DSL does), calling `next` after stepping into the first part of a chained call (e.g. get_session.method(:check).call(label)) causes byebug to skip the rest of the chain and return to the outer caller instead of staying on the same line.

The test mimics Capybara's pattern of:
  page.method("check").call(...)

and asserts that after step/step/next, the debugger should be back on the class_eval method body line (11), not the outer caller (line 24).

Ref: https://github.com/deivid-rodriguez/byebug/issues/877