### PR TITLE
Fixes for minitest 6 and ruby 4

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "bundler"
+Bundler.require
+
 import "tasks/compile.rake"
 import "tasks/test.rake"
 import "tasks/release.rake"

--- a/lib/byebug/frame.rb
+++ b/lib/byebug/frame.rb
@@ -37,7 +37,12 @@ module Byebug
     end
 
     def _method
-      @context.frame_method(pos)
+      result = @context.frame_method(pos)
+      if RUBY_VERSION > "4.0"
+        result[/(?:#|::)(\w+)$/, 1]
+      else
+        result
+      end
     end
 
     def _unqualified_method

--- a/test/commands/frame_test.rb
+++ b/test/commands/frame_test.rb
@@ -77,10 +77,22 @@ module Byebug
     def test_frame_minus_one_sets_frame_to_the_last_one
       enter "frame -1"
 
+      # TODO: isn't the "last" frame the one byebug stopped on? that'd be 16, not 1
       debug_code(program) { assert_location example_path, 1 }
     end
 
+    def test_frame_zero_sets_frame_to_the_first_one
+      enter "frame 0"
+
+      # TODO: same as above, but opposite
+      debug_code(program) { assert_location example_path, 16 }
+    end
+
+    def skip_ruby4 = (skip "ruby 4 changed c frames" if RUBY_VERSION > "4")
+
     def test_frame_cannot_navigate_to_c_frames
+      skip_ruby4
+
       enter "frame 3"
       debug_code(program)
 

--- a/test/processors/command_processor_test.rb
+++ b/test/processors/command_processor_test.rb
@@ -135,7 +135,7 @@ module Byebug
       debug_code(minimal_program)
 
       assert_error_includes "ZeroDivisionError Exception: divided by 0"
-      assert_error_doesnt_include(/\S+:\d+:in `eval':divided by 0/)
+      assert_error_doesnt_include(/\S+:\d+:in .(?:Binding#)?eval'/)
     end
   end
 


### PR DESCRIPTION
- Move check_* test methods to assert_* methods to fix failure locations.
- **CONTROVERSIAL: remove bin/runner and friends**
- **CONTROVERSIAL: replace faraday with open-uri**
- **Miscellaneous test fixes for ruby 4**
- **Don't require bundle exec for every damn thing. Autorequire in Rakefile**
